### PR TITLE
BACKLOG-13968 upgrade scribe api to fix facebook and google connector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
         <dependency>
             <groupId>com.github.scribejava</groupId>
             <artifactId>scribejava-apis</artifactId>
-            <version>4.1.2</version>
+            <version>6.8.1</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.gemini.blueprint</groupId>

--- a/src/main/java/org/jahia/modules/jahiaoauth/service/JahiaOAuthService.java
+++ b/src/main/java/org/jahia/modules/jahiaoauth/service/JahiaOAuthService.java
@@ -43,8 +43,6 @@
  */
 package org.jahia.modules.jahiaoauth.service;
 
-import com.github.scribejava.core.builder.api.BaseApi;
-import com.github.scribejava.core.oauth.OAuth20Service;
 import org.jahia.services.content.JCRNodeWrapper;
 
 import javax.jcr.RepositoryException;
@@ -125,10 +123,4 @@ public interface JahiaOAuthService {
      */
     Map<String, Object> requestUserData(JCRNodeWrapper jahiaOAuthNode, String connectorServiceName, String mapperServiceName, String refreshToken) throws Exception;
 
-    /**
-     * This method allow to set oAuthBase20ApiMap property
-     *
-     * @param oAuthBase20ApiMap Map contains key value of scribejava API
-     */
-    void setoAuthBase20ApiMap(Map<String, BaseApi<? extends OAuth20Service>> oAuthBase20ApiMap);
 }

--- a/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -4,7 +4,7 @@
            xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
 
     <bean id="jahiaOAuthServiceImpl" class="org.jahia.modules.jahiaoauth.impl.JahiaOAuthServiceImpl">
-        <property name="oAuthBase20ApiMap">
+        <property name="oAuthDefaultApi20Map">
             <map>
                 <entry key="LinkedInApi20">
                     <bean class="com.github.scribejava.apis.LinkedInApi20"/>
@@ -52,7 +52,9 @@
                     <bean class="com.github.scribejava.apis.OdnoklassnikiApi"/>
                 </entry>
                 <entry key="FacebookApi">
-                    <bean class="com.github.scribejava.apis.FacebookApi"/>
+                    <bean class="com.github.scribejava.apis.FacebookApi">
+                        <argument value="7.0"/>
+                    </bean>
                 </entry>
                 <entry key="TutByApi">
                     <bean class="com.github.scribejava.apis.TutByApi"/>


### PR DESCRIPTION
## JIRA
https://jira.jahia.org/browse/BACKLOG-13968

## Description
upgrade scribejava API to the latest working version 6.8.1 to fix Facebook and Google connector

## Tests
The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist
I have considered the following implications of my change: 

- [x] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [x] Performance
- [x] Migration
- [x] Code maintainability

## Documentation

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
