### PR TITLE
chore: bump/override transitive jackson-databind to 2.20.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,8 +110,8 @@
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>2.12.0</version>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.20.0</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.gemini.blueprint</groupId>


### PR DESCRIPTION
### Description

Bump/override transitive jackson libraries (databind, core) to 2.20.0

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
