### PR TITLE
chore(deps): Bump scribejava-apis from 8.1.0 to 8.3.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
         <dependency>
             <groupId>com.github.scribejava</groupId>
             <artifactId>scribejava-apis</artifactId>
-            <version>8.1.0</version>
+            <version>8.3.3</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Closes https://github.com/Jahia/jahia-private/issues/4602.

Precedes https://github.com/Jahia/jahia-oauth/pull/113.

### Description
Bump _com.github.scribejava:scribejava-apis_ from 8.1.0 to 8.3.3.
Fixes a few [SonarQube issues](https://sonarqube.jahia.com/project/issues?fixedInPullRequest=113&id=org.jahia.modules%3Ajahia-oauth).

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
