### PR TITLE
chore(deps): Bump jackson-core and jackson-databind to 2.20.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,10 +108,23 @@
             <artifactId>scribejava-apis</artifactId>
             <version>8.3.3</version>
         </dependency>
+        <!-- overwrite the versions of the Jackson libs coming from scribejava-apis to use the latest -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.12.0</version>
+            <version>2.20.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.20.1</version>
+            <exclusions>
+                <exclusion>
+                    <!-- provided by Jahia since 8.0.0.0 (https://github.com/Jahia/jahia/blob/JAHIA_8_0_0_0/features/jackson/pom.xml#L79) -->
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.eclipse.gemini.blueprint</groupId>


### PR DESCRIPTION
Closes https://github.com/Jahia/jahia-private/issues/4602.
~Requires https://github.com/Jahia/jahia-oauth/pull/112 to be merged first!~

### Description
Bump Jackson libraries by overriding the versions transitively pulled by _com.github.scribejava:scribejava-apis_.

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
