### PR TITLE
chore: Remove references to Blueprint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <jahia-depends>jahia-authentication</jahia-depends>
         <export-package>org.jahia.modules.jahiaoauth.service,org.jahia.modules.jahiaoauth.action,com.github.scribejava.*</export-package>
         <jahia-static-resources>/css,/images,/javascript,/icons</jahia-static-resources>
-        <require-capability>osgi.extender;filter:="(osgi.extender=org.jahia.bundles.blueprint.extender.config)", org.jahia.license;filter:="(key=org.jahia.oauthConnector)"</require-capability>
+        <require-capability>org.jahia.license;filter:="(key=org.jahia.oauthConnector)"</require-capability>
         <jahia-key>org.jahia.oauthConnector</jahia-key>
         <jahia-module-signature>MCwCFDDkxDn7XlitPSkGqP3GfYp1EU60AhReTMK+K7qVp6PrqpaYubH8YqHVLg==</jahia-module-signature>
         <jahia.modules.importPackage>!com.hazelcast.config,!com.hazelcast.core</jahia.modules.importPackage>
@@ -112,12 +112,6 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
             <version>2.12.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.gemini.blueprint</groupId>
-            <artifactId>gemini-blueprint-core</artifactId>
-            <version>1.0.2.RELEASE</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.hazelcast</groupId>


### PR DESCRIPTION
### Description
Following https://github.com/Jahia/jahia-oauth/pull/109 (migration from Blueprint to OSGi Declaration Services), there are some remaining references to Blueprint that should now be removed.

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
