### PR TITLE
ci: Fix provisioning files and Jahia image for nightly tests

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,7 +15,7 @@ jobs:
             pagerduty_service: jahia-oauth-JahiaRL
             provisioning_manifest: provisioning-manifest-snapshot.yml
           - name: Snapshot
-            jahia_image: jahia/jahia-ee:8-SNAPSHOT
+            jahia_image: ghcr.io/jahia/jahia-ee-dev:8-SNAPSHOT
             pagerduty_service: jahia-oauth-JahiaSN
             provisioning_manifest: provisioning-manifest-snapshot.yml
     uses: Jahia/jahia-modules-action/.github/workflows/reusable-integration-tests.yml@v2

--- a/tests/assets/snapshots.yml
+++ b/tests/assets/snapshots.yml
@@ -1,6 +1,6 @@
 - installModule:
     # The range should match the current version of the module in the pom.xml
-    - 'mvn:org.jahia.modules/jahia-oauth/[2.0-SNAPSHOT,3.0-SNAPSHOT)'
-    - 'mvn:org.jahia.test/jahia-oauth-test-module/[2.0-SNAPSHOT,3.0-SNAPSHOT)'
+    - 'mvn:org.jahia.modules/jahia-oauth/[3.0-SNAPSHOT,4.0-SNAPSHOT)'
+    - 'mvn:org.jahia.test/jahia-oauth-test-module/[3.0-SNAPSHOT,4.0-SNAPSHOT)'
   autoStart: true
   uninstallPreviousVersion: true


### PR DESCRIPTION
Fixes https://github.com/Jahia/jahia-oauth/issues/120.
### Description
Fix the incorrect Jahia version and modules versions of https://github.com/Jahia/jahia-oauth/pull/119, causing the [nightly tests to fail](https://github.com/Jahia/jahia-oauth/actions/runs/21156535219).


> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
