### PR TITLE
feat: support for nested fields

### DIFF
--- a/.chachalog/Ezc5YqlA.md
+++ b/.chachalog/Ezc5YqlA.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+jahia-oauth: minor
+---
+
+Enabled mapping of nested and array-valued properties from an identity-provider token

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
-            <version>2.9.0</version>
+            <version>2.10.0</version>
             <exclusions>
                 <!-- slf4j-api is provided by the Jahia OSGi container (1.7.x).
                      Excluding the transitive 2.0.x pulled by json-path avoids a

--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,20 @@
             <version>2.12.0</version>
         </dependency>
         <dependency>
+            <groupId>com.jayway.jsonpath</groupId>
+            <artifactId>json-path</artifactId>
+            <version>2.9.0</version>
+            <exclusions>
+                <!-- slf4j-api is provided by the Jahia OSGi container (1.7.x).
+                     Excluding the transitive 2.0.x pulled by json-path avoids a
+                     version conflict that would cause runtime classloading failures. -->
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast-all</artifactId>
             <version>3.7.3</version>

--- a/src/main/java/org/jahia/modules/jahiaoauth/impl/JahiaOAuthServiceImpl.java
+++ b/src/main/java/org/jahia/modules/jahiaoauth/impl/JahiaOAuthServiceImpl.java
@@ -246,10 +246,9 @@ public class JahiaOAuthServiceImpl implements JahiaOAuthService {
      * the Jayway JsonPath library. Plain property names (no {@code $} prefix) fall back to a
      * top-level {@code has}/{@code opt} lookup.
      * <p>
-     * Only scalar types ({@code String}, {@code Number}, {@code Boolean}), {@code List}, and
-     * {@code null} are returned. Complex values ({@code JSONObject} or any other unexpected type)
-     * are skipped with a warning; use the connector's {@code availableProperties} with
-     * {@code valuePath} for those.
+     * All value types are returned as-is. Note that complex types (e.g. {@code JSONObject}) will
+     * be converted to their string representation by {@code JahiaAuthMapperServiceImpl.executeMapper}
+     * when stored in the cache; they are only usable as-is in a custom {@link ConnectorResultProcessor}.
      * <p>
      * Jayway note: filter expressions always return a list, even when only one node matches
      * (e.g. {@code $.groups[?(@.name == 'admin')]} returns {@code ["admin"]}, not {@code "admin"}).
@@ -289,18 +288,10 @@ public class JahiaOAuthServiceImpl implements JahiaOAuthService {
             }
         }
 
-        // Only extract simple types: String, Number (Integer, Long, Double), Boolean, List or null
-        if (matchingProperty == null || matchingProperty instanceof String || matchingProperty instanceof Number
-                || matchingProperty instanceof Boolean || matchingProperty instanceof List) {
-            logger.debug("Property '{}' found in JSON response with value '{}'", connectorProperty, matchingProperty);
-            return new AbstractMap.SimpleEntry<>(connectorProperty, matchingProperty);
-        } else {
-            // Skip complex types (JSONObject, or any other unexpected types)
-            logger.warn(
-                    "Skipping non-simple property '{}' of type '{}' - use connector's availableProperties with valuePath for complex values",
-                    connectorProperty, matchingProperty.getClass().getSimpleName());
-            return null;
-        }
+        logger.debug("Property '{}' found in JSON response with value '{}'", connectorProperty, matchingProperty);
+        // NB: the complex types (JSONObject, or any other unexpected types) can only be used in a custom ConnectorResultProcessor
+        // in JahiaAuthMapperServiceImpl.executeMapper(...), the property result is stored in the cache as a string: String.valueOf(...)
+        return new AbstractMap.SimpleEntry<>(connectorProperty, matchingProperty);
     }
 
     /**

--- a/src/main/java/org/jahia/modules/jahiaoauth/impl/JahiaOAuthServiceImpl.java
+++ b/src/main/java/org/jahia/modules/jahiaoauth/impl/JahiaOAuthServiceImpl.java
@@ -24,6 +24,8 @@ import com.github.scribejava.core.model.OAuthRequest;
 import com.github.scribejava.core.model.Response;
 import com.github.scribejava.core.model.Verb;
 import com.github.scribejava.core.oauth.OAuth20Service;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
 import org.apache.commons.lang.StringUtils;
 import org.jahia.modules.jahiaauth.service.*;
 import org.jahia.modules.jahiaoauth.service.*;
@@ -54,6 +56,7 @@ import java.util.concurrent.ConcurrentHashMap;
 @Component(service = JahiaOAuthService.class, immediate = true)
 public class JahiaOAuthServiceImpl implements JahiaOAuthService {
     private static final Logger logger = LoggerFactory.getLogger(JahiaOAuthServiceImpl.class);
+    private static final Configuration JSONPATH_CONFIG = Configuration.builder().build();
 
     private final Map<String, JahiaOAuthAPIBuilder> oAuthDefaultApi20Map;
 
@@ -236,8 +239,23 @@ public class JahiaOAuthServiceImpl implements JahiaOAuthService {
     }
 
     /**
-     * Extracts a single property for a mapping if it exists in the JSON response and hasn't been extracted yet.
-     * Only supports simple types (String, Number, Boolean).
+     * Extracts a single property for a mapping if it is present in the JSON response and has not
+     * already been extracted via the connector's {@code availableProperties}.
+     * <p>
+     * Connector property values starting with {@code $} are evaluated as JSONPath expressions via
+     * the Jayway JsonPath library. Plain property names (no {@code $} prefix) fall back to a
+     * top-level {@code has}/{@code opt} lookup and emit a deprecation warning.
+     * <p>
+     * Only scalar types ({@code String}, {@code Number}, {@code Boolean}), {@code List}, and
+     * {@code null} are returned. Complex values ({@code JSONObject} or any other unexpected type)
+     * are skipped with a warning; use the connector's {@code availableProperties} with
+     * {@code valuePath} for those.
+     * <p>
+     * Jayway note: filter expressions always return a list, even when only one node matches
+     * (e.g. {@code $.groups[?(@.name == 'admin')]} returns {@code ["admin"]}, not {@code "admin"}).
+     * Additionally, chaining an index selector after a filter — e.g. {@code [?(@.x == 'y')][1]} —
+     * does <em>not</em> index into the filtered nodelist; {@code [1]} is applied to each matched
+     * node individually and produces nothing since matched nodes are objects, not arrays.
      */
     private static Map.Entry<String, Object> extractEnhancedPropertyEntryForMapping(Map<String, Object> propertiesResult, JSONObject responseJson, Mapping mapping) {
         String connectorProperty = mapping.getConnectorProperty();
@@ -249,27 +267,54 @@ public class JahiaOAuthServiceImpl implements JahiaOAuthService {
             return null;
         }
 
-        // Try to find property in raw JSON properties
-        if (!responseJson.has(connectorProperty)) {
-            logger.debug("Property '{}' not found in JSON response", connectorProperty);
-            return null;
+        Object matchingProperty;
+
+        if (connectorProperty.startsWith("$")) {
+            // RFC 9535 JSONPath expression
+            matchingProperty = evaluateJsonPath(responseJson, connectorProperty);
+            if (matchingProperty == null) {
+                logger.debug("JSONPath expression '{}' returned no result in JSON response", connectorProperty);
+                return null;
+            }
+        } else {
+            // Legacy: plain top-level property name — deprecated
+            logger.warn("Connector property '{}' does not use JSONPath syntax (RFC 9535). "
+                    + "This syntax is deprecated and will be removed in the next major release. "
+                    + "Please switch to JSONPath syntax instead (e.g. '$.{}').", connectorProperty, connectorProperty);
+            if (!responseJson.has(connectorProperty)) {
+                logger.debug("Property '{}' not found in JSON response", connectorProperty);
+                return null;
+            }
+            matchingProperty = responseJson.opt(connectorProperty);
+            if (JSONObject.NULL.equals(matchingProperty)) {
+                matchingProperty = null;
+            }
         }
 
-        Object matchingProperty = responseJson.opt(connectorProperty);
-        if (JSONObject.NULL.equals(matchingProperty)) {
-            matchingProperty = null;
-        }
-
-        // Only extract simple types: String, Number (Integer, Long, Double), Boolean, or null
+        // Only extract simple types: String, Number (Integer, Long, Double), Boolean, List or null
         if (matchingProperty == null || matchingProperty instanceof String || matchingProperty instanceof Number
-                || matchingProperty instanceof Boolean) {
+                || matchingProperty instanceof Boolean || matchingProperty instanceof List) {
             logger.debug("Property '{}' found in JSON response with value '{}'", connectorProperty, matchingProperty);
             return new AbstractMap.SimpleEntry<>(connectorProperty, matchingProperty);
         } else {
-            // Skip complex types (JSONObject, JSONArray, or any other unexpected types)
+            // Skip complex types (JSONObject, or any other unexpected types)
             logger.warn(
                     "Skipping non-simple property '{}' of type '{}' - use connector's availableProperties with valuePath for complex values",
                     connectorProperty, matchingProperty.getClass().getSimpleName());
+            return null;
+        }
+    }
+
+    /**
+     * Evaluates a JSONPath expression (RFC 9535) against the given JSON object.
+     * Returns {@code null} if the path does not exist or evaluation fails.
+     */
+    private static Object evaluateJsonPath(JSONObject responseJson, String jsonPathExpression) {
+        try {
+            return JsonPath.using(JSONPATH_CONFIG).parse(responseJson.toString()).read(jsonPathExpression);
+        } catch (Exception e) {
+            logger.warn("Failed to evaluate JSONPath expression '{}': {}", jsonPathExpression, e.getMessage());
+            logger.debug("Stacktrace", e);
             return null;
         }
     }

--- a/src/main/java/org/jahia/modules/jahiaoauth/impl/JahiaOAuthServiceImpl.java
+++ b/src/main/java/org/jahia/modules/jahiaoauth/impl/JahiaOAuthServiceImpl.java
@@ -244,7 +244,7 @@ public class JahiaOAuthServiceImpl implements JahiaOAuthService {
      * <p>
      * Connector property values starting with {@code $} are evaluated as JSONPath expressions via
      * the Jayway JsonPath library. Plain property names (no {@code $} prefix) fall back to a
-     * top-level {@code has}/{@code opt} lookup and emit a deprecation warning.
+     * top-level {@code has}/{@code opt} lookup.
      * <p>
      * Only scalar types ({@code String}, {@code Number}, {@code Boolean}), {@code List}, and
      * {@code null} are returned. Complex values ({@code JSONObject} or any other unexpected type)
@@ -271,16 +271,14 @@ public class JahiaOAuthServiceImpl implements JahiaOAuthService {
 
         if (connectorProperty.startsWith("$")) {
             // RFC 9535 JSONPath expression
+            logger.debug("Evaluating the connector property {} as a JSONPath expression", connectorProperty);
             matchingProperty = evaluateJsonPath(responseJson, connectorProperty);
             if (matchingProperty == null) {
                 logger.debug("JSONPath expression '{}' returned no result in JSON response", connectorProperty);
                 return null;
             }
         } else {
-            // Legacy: plain top-level property name — deprecated
-            logger.warn("Connector property '{}' does not use JSONPath syntax (RFC 9535). "
-                    + "This syntax is deprecated and will be removed in the next major release. "
-                    + "Please switch to JSONPath syntax instead (e.g. '$.{}').", connectorProperty, connectorProperty);
+            logger.debug("Evaluating the connector property {} as a plain property name lookup", connectorProperty);
             if (!responseJson.has(connectorProperty)) {
                 logger.debug("Property '{}' not found in JSON response", connectorProperty);
                 return null;

--- a/tests/cypress/e2e/connectors.cy.ts
+++ b/tests/cypress/e2e/connectors.cy.ts
@@ -53,7 +53,7 @@ interface ConnectorConfig<TUser> {
     userGenerator: () => TUser;
     registerAuthorizeMock: (siteKey: string, credentials: ClientCredentials, authCode: string) => Cypress.Chainable;
     registerTokenMock: (authCode: string) => Cypress.Chainable;
-    registerUserInfoMock: (user: TUser, customFields?: Record<string, string>) => Cypress.Chainable;
+    registerUserInfoMock: (user: TUser, customFields?: Record<string, unknown>) => Cypress.Chainable;
     expectedFieldsMapper: (user: TUser) => Record<string, string>;
 }
 
@@ -231,28 +231,153 @@ connectors.forEach(connector => {
             testSuccessfulAuthentication(config);
         });
 
-        it('Should display user details and the custom fields when successfully authenticated', () => {
-            // Configure additional custom fields
-            const customFields = {
-                customField: faker.lorem.word(),
-                otherField: faker.lorem.word()
+        const mappingFields = [
+            {name: 'dot notation - deprecated', customField: 'customField', otherField: 'otherField'},
+            {name: 'RFC 9535 notation', customField: '$.customField', otherField: '$.otherField'}
+        ];
+        mappingFields.forEach(mapping => {
+            it(`Should display user details and the custom fields (mapped with ${mapping.name}) when successfully authenticated`, () => {
+                // Configure additional custom fields
+                const customFields = {
+                    customField: faker.lorem.word(),
+                    otherField: faker.lorem.word()
+                };
+
+                // Create custom mapping: customField -> j:organization, otherField -> j:twitterID
+                const customMapping = [
+                    {
+                        connector: {valueType: 'string', name: mapping.customField},
+                        editable: false,
+                        mapper: {
+                            valueType: 'string',
+                            name: 'j:organization',
+                            mandatory: false
+                        }
+                    },
+                    {
+                        connector: {valueType: 'string', name: mapping.otherField},
+                        editable: false,
+                        mapper: {
+                            valueType: 'string',
+                            name: 'j:twitterID',
+                            mandatory: false
+                        }
+                    }
+                ];
+
+                // Re-configure the connector with custom mapping
+                connector.configurator(siteKey, clientCredentials, customMapping);
+
+                const config: OAuthConnectorTestConfig<OAuthUser> = {
+                    connectorName: connector.name,
+                    pageUrl: `/sites/${siteKey}/${connector.name.toLowerCase()}.html`,
+                    buttonSelector: connector.buttonSelector,
+                    credentials: clientCredentials,
+                    user: user,
+                    authCode: authCode,
+                    siteKey: siteKey,
+                    registerAuthorizeMock: connector.registerAuthorizeMock,
+                    registerTokenMock: connector.registerTokenMock,
+                    registerUserInfoMock: connector.registerUserInfoMock,
+                    expectedUserFields: {
+                        ...connector.expectedFieldsMapper(user),
+                        // Custom fields mapped to predefined properties
+                        organization: customFields.customField,
+                        twitterID: customFields.otherField
+                    },
+                    customFields: customFields
+                };
+
+                cy.logout();
+                testSuccessfulAuthentication(config);
+            });
+        });
+
+        it('Should display user details and the custom nested fields (defined using RFC 9535-compliant syntax / Jayway) when successfully authenticated', () => {
+            // Demonstrates mapping scenarios using RFC 9535 syntax:
+            //   - $.nestedLevel.simpleField -> simple nested field access
+            //   - $.nestedLevel.simpleArray -> array access
+            //   - $.nestedLevel.complexFiltering[?(@.code =~ /ABC-[0-9]+/ && @.category == 'bar')].name -> advanced filtering
+            //
+            // Note: Jayway is not a strict RFC 9535 implementation. The spec's match() and
+            // search() filter functions are not supported; use the =~ operator instead.
+            // String values in filter predicates must use single quotes.
+
+            const simpleField = faker.string.uuid();
+            const simpleArrayWord1 = faker.lorem.word();
+            const simpleArrayWord2 = faker.lorem.word();
+            const name1 = faker.lorem.slug();
+            const name2 = faker.lorem.slug();
+            const name3 = faker.lorem.slug();
+            const customNestedFields = {
+                nestedLevel: {
+                    simpleField: simpleField,
+                    simpleArray: [simpleArrayWord1, simpleArrayWord2],
+                    complexFiltering: [
+                        {
+                            name: name1,
+                            category: 'foo',
+                            code: `ABC-${faker.number.int({min: 100, max: 999})}`
+                        },
+                        {
+                            name: name2,
+                            category: 'bar',
+                            code: `DEF-${faker.number.int({min: 100, max: 999})}`
+                        },
+                        {
+                            name: name3,
+                            category: 'bar',
+                            code: `ABC-${faker.number.int({min: 100, max: 999})}`
+                        }
+                    ]
+                }
             };
 
-            // Create custom mapping: customField -> j:organization, otherField -> j:twitterID
             const customMapping = [
                 {
-                    connector: {valueType: 'string', name: 'customField'},
+                    connector: {
+                        valueType: 'string',
+                        name: '$.nestedLevel.simpleField'
+                    },
                     editable: false,
-                    mapper: {valueType: 'string', name: 'j:organization', mandatory: false}
+                    mapper: {
+                        valueType: 'string',
+                        name: 'j:organization',
+                        mandatory: false
+                    }
                 },
                 {
-                    connector: {valueType: 'string', name: 'otherField'},
+                // This field is then used in CustomConnectorResultProcessor for custom manipulation
+                // NB: the property this field is mapped to (j:skypeID in this example) MUST be defined in the `mappings` field of `org.jahia.modules.jcroauthprovider.impl.JCROAuthProviderMapperImpl.cfg`!
+                    connector: {
+                        valueType: 'string',
+                        name: '$.nestedLevel.simpleArray'
+                    },
                     editable: false,
-                    mapper: {valueType: 'string', name: 'j:twitterID', mandatory: false}
+                    mapper: {
+                        valueType: 'string',
+                        name: 'j:skypeID',
+                        mandatory: false
+                    }
+                },
+                {
+                // Compound filter: regex on code AND equality on category — only name3 matches.
+                // Jayway always returns a nodelist for filter expressions, so even a single match
+                // produces a one-element list. The mapper layer serialises it as a JSON array string
+                // (["name3"]), consistent with multi-element results (see simpleArray / j:skypeID above).
+                    connector: {
+                        valueType: 'string',
+                        name: '$.nestedLevel.complexFiltering[?(@.code =~ /ABC-[0-9]+/ && @.category == \'bar\')].name'
+                    },
+                    editable: false,
+                    mapper: {
+                        valueType: 'string',
+                        name: 'j:twitterID',
+                        mandatory: false
+                    }
                 }
             ];
 
-            // Re-configure the connector with custom mapping
             connector.configurator(siteKey, clientCredentials, customMapping);
 
             const config: OAuthConnectorTestConfig<OAuthUser> = {
@@ -268,11 +393,12 @@ connectors.forEach(connector => {
                 registerUserInfoMock: connector.registerUserInfoMock,
                 expectedUserFields: {
                     ...connector.expectedFieldsMapper(user),
-                    // Custom fields mapped to predefined properties
-                    organization: customFields.customField,
-                    twitterID: customFields.otherField
+                    organization: simpleField,
+                    customProperty: simpleArrayWord1 + '_' + simpleArrayWord2, // CustomConnectorResultProcessor joins the values with a "_"
+                    skypeID: '["' + simpleArrayWord1 + '","' + simpleArrayWord2 + '"]',
+                    twitterID: '["' + name3 + '"]'
                 },
-                customFields: customFields
+                customFields: customNestedFields
             };
 
             cy.logout();

--- a/tests/cypress/e2e/utils/mocking.ts
+++ b/tests/cypress/e2e/utils/mocking.ts
@@ -88,7 +88,7 @@ export function registerGoogleOauthTokenMock(authCode: string) {
     }).then(response => response.body);
 }
 
-export function registerGoogleUserInfoMock(user: GoogleUser, customFields?: Record<string, string>) {
+export function registerGoogleUserInfoMock(user: GoogleUser, customFields?: Record<string, unknown>) {
     const wiremockBaseUrl = getWiremockBaseUrl();
     cy.log(`Registering Google user info mock for user ${user.sub}`);
     cy.log('custom fields: ', customFields || 'none');
@@ -193,7 +193,7 @@ export function registerLinkedInOauthTokenMock(authCode: string) {
     }).then(response => response.body);
 }
 
-export function registerLinkedInUserInfoMocks(user: LinkedInUser, customFields?: Record<string, string>) {
+export function registerLinkedInUserInfoMocks(user: LinkedInUser, customFields?: Record<string, unknown>) {
     const wiremockBaseUrl = getWiremockBaseUrl();
 
     cy.log(`Registering LinkedIn user info mock for user ${user.id}`);
@@ -342,7 +342,7 @@ export function registerGitHubOauthTokenMock(authCode: string) {
     }).then(response => response.body);
 }
 
-export function registerGitHubUserInfoMock(user: GitHubUser, customFields?: Record<string, string>) {
+export function registerGitHubUserInfoMock(user: GitHubUser, customFields?: Record<string, unknown>) {
     const wiremockBaseUrl = getWiremockBaseUrl();
 
     cy.log(`Registering GitHub user info mock for user ${user.id}`);
@@ -444,7 +444,7 @@ export function registerFacebookOauthTokenMock(authCode: string) {
     }).then(response => response.body);
 }
 
-export function registerFacebookUserInfoMock(user: FacebookUser, customFields?: Record<string, string>) {
+export function registerFacebookUserInfoMock(user: FacebookUser, customFields?: Record<string, unknown>) {
     const wiremockBaseUrl = getWiremockBaseUrl();
 
     cy.log(`Registering Facebook user info mock for user ${user.id}`);

--- a/tests/cypress/e2e/utils/testScenarios.ts
+++ b/tests/cypress/e2e/utils/testScenarios.ts
@@ -63,9 +63,9 @@ export interface OAuthConnectorTestConfig<TUser> {
     siteKey: string;
     registerAuthorizeMock: (siteKey: string, credentials: ClientCredentials, authCode: string) => Cypress.Chainable;
     registerTokenMock: (authCode: string) => Cypress.Chainable;
-    registerUserInfoMock: (user: TUser, customFields?: Record<string, string>) => Cypress.Chainable;
+    registerUserInfoMock: (user: TUser, customFields?: Record<string, unknown>) => Cypress.Chainable;
     expectedUserFields: ExpectedUserFields; // Fields to validate after authentication - supports both predefined and custom fields
-    customFields?: Record<string, string>; // Custom fields to pass to registerUserInfoMock
+    customFields?: Record<string, unknown>; // Custom fields to pass to registerUserInfoMock
 }
 
 /**

--- a/tests/jahia-module/src/main/java/org/jahia/test/jahiaoauth/CustomConnectorResultProcessor.java
+++ b/tests/jahia-module/src/main/java/org/jahia/test/jahiaoauth/CustomConnectorResultProcessor.java
@@ -80,10 +80,10 @@ public class CustomConnectorResultProcessor implements ConnectorResultProcessor 
         // This processor runs for every successful OAuth authentication (it is an OSGi service),
         // so connectors not configured with the $.nestedLevel.simpleArray mapping will have a
         // null simpleArray value — which must not cause a NullPointerException.
-        if (login instanceof String && simpleArray instanceof List) {
+        if (login != null && simpleArray instanceof List) {
             try {
                 jcrTemplate.doExecuteWithSystemSession(session -> {
-                    JCRUserNode user = jahiaUserManagerService.lookupUser((String) login, session);
+                    JCRUserNode user = jahiaUserManagerService.lookupUser(login.toString(), session);
                     String simpleArrayJoined = ((List<?>) simpleArray).stream().map(Object::toString).collect(Collectors.joining("_"));
                     user.setProperty("customProperty", simpleArrayJoined);
                     session.save();

--- a/tests/jahia-module/src/main/java/org/jahia/test/jahiaoauth/CustomConnectorResultProcessor.java
+++ b/tests/jahia-module/src/main/java/org/jahia/test/jahiaoauth/CustomConnectorResultProcessor.java
@@ -1,0 +1,97 @@
+/*
+ * ==========================================================================================
+ * =                            JAHIA'S ENTERPRISE DISTRIBUTION                             =
+ * ==========================================================================================
+ *
+ *                                  http://www.jahia.com
+ *
+ * JAHIA'S ENTERPRISE DISTRIBUTIONS LICENSING - IMPORTANT INFORMATION
+ * ==========================================================================================
+ *
+ *     Copyright (C) 2002-2026 Jahia Solutions Group. All rights reserved.
+ *
+ *     This file is part of a Jahia's Enterprise Distribution.
+ *
+ *     Jahia's Enterprise Distributions must be used in accordance with the terms
+ *     contained in the Jahia Solutions Group Terms &amp; Conditions as well as
+ *     the Jahia Sustainable Enterprise License (JSEL).
+ *
+ *     For questions regarding licensing, support, production usage...
+ *     please contact our team at sales@jahia.com or go to http://www.jahia.com/license.
+ *
+ * ==========================================================================================
+ */
+package org.jahia.test.jahiaoauth;
+
+import org.jahia.api.content.JCRTemplate;
+import org.jahia.api.usermanager.JahiaUserManagerService;
+import org.jahia.modules.jahiaauth.service.ConnectorConfig;
+import org.jahia.modules.jahiaauth.service.ConnectorResultProcessor;
+import org.jahia.services.content.decorator.JCRUserNode;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+import javax.jcr.RepositoryException;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Test-only {@link ConnectorResultProcessor} that demonstrates post-processing of complex
+ * (list-valued) connector results obtained via JSONPath expressions.
+ *
+ * <p>When the active connector mapping includes the JSONPath expression
+ * {@code $.nestedLevel.simpleArray}, this processor joins the resolved array elements with
+ * {@code _} and writes the result to the {@code customProperty} JCR property of the
+ * authenticated user.
+ *
+ * <p>This mirrors a real-world pattern: a JSONPath expression such as
+ * {@code $.authorization_context.groups} can extract a multi-valued list from an identity-
+ * provider token (e.g. Keycloak), pass it as a raw {@code List} through the connector
+ * pipeline, and then a custom {@link ConnectorResultProcessor} implementation can turn it
+ * into whatever the application needs (group-membership updates, comma-separated strings,
+ * role assignments, etc.).
+ *
+ * <p><strong>Note:</strong> this component is registered as an OSGi service and is therefore
+ * invoked for <em>every</em> successful OAuth authentication in the test environment, not
+ * only the nested-fields test. The implementation guards against the case where the mapping
+ * is absent.
+ */
+@Component(immediate = true, service = ConnectorResultProcessor.class)
+public class CustomConnectorResultProcessor implements ConnectorResultProcessor {
+    private JahiaUserManagerService jahiaUserManagerService;
+    private JCRTemplate jcrTemplate;
+
+    @Reference
+    public void setJahiaUserManagerService(JahiaUserManagerService jahiaUserManagerService) {
+        this.jahiaUserManagerService = jahiaUserManagerService;
+    }
+
+    @Reference
+    public void setJcrTemplate(JCRTemplate jcrTemplate) {
+        this.jcrTemplate = jcrTemplate;
+    }
+
+    @Override
+    public void execute(ConnectorConfig connectorConfig, Map<String, Object> results) {
+        Object login = results.get("id");
+        Object simpleArray = results.get("$.nestedLevel.simpleArray");
+        // Guard: only execute when both the user login and the array value are present.
+        // This processor runs for every successful OAuth authentication (it is an OSGi service),
+        // so connectors not configured with the $.nestedLevel.simpleArray mapping will have a
+        // null simpleArray value — which must not cause a NullPointerException.
+        if (login instanceof String && simpleArray instanceof List) {
+            try {
+                jcrTemplate.doExecuteWithSystemSession(session -> {
+                    JCRUserNode user = jahiaUserManagerService.lookupUser((String) login, session);
+                    String simpleArrayJoined = ((List<?>) simpleArray).stream().map(Object::toString).collect(Collectors.joining("_"));
+                    user.setProperty("customProperty", simpleArrayJoined);
+                    session.save();
+                    return null;
+                });
+            } catch (RepositoryException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes https://github.com/Jahia/jahia-oauth/issues/145.
### Description
Enables mapping of nested and array-valued properties from an identity-provider token (e.g. `authorization_context.user_id` or `authorization_context.groups` from Keycloak).

### Approach

Custom mapper property names prefixed with `$` are now evaluated as **JSONPath expressions** (via [Jayway JsonPath](https://github.com/json-path/JsonPath)) against the token's JSON response. Plain names without a `$` prefix continue to work as before (top-level lookup).

JSONPath was chosen over simple dot notation because dot notation is ambiguous when key names contain dots, has no standard for array access, and cannot express filter predicates. JSONPath (RFC 9535) covers all these cases cleanly with bracket notation, index access, and filter expressions.

Filter expressions always return a list — even a single match produces `["value"]`. Use direct-path expressions (e.g. `$.authorization_context.user_id`) when a scalar is needed, and a `ConnectorResultProcessor` implementation when further manipulation of list values is required (see `CustomConnectorResultProcessor` in the test module for an example).

### Changes

- **`JahiaOAuthServiceImpl`**: `extractEnhancedPropertyEntryForMapping` now branches on the `$` prefix — JSONPath evaluation via Jayway, or top-level lookup (as before). `List` is added to the accepted return types alongside `String`, `Number`, and `Boolean`.
- **`pom.xml`**: added `com.jayway.jsonpath:json-path:2.9.0` (with `slf4j-api` excluded to avoid version conflict with the OSGi container) as an **embedded library** with its transitive dependencies: `net.minidev:json-smart:2.5.0`, `net.minidev:accessors-smart:2.5.0` and `org.ow2.asm:asm:9.3`.
- **Tests**: new Cypress scenario covering simple nested fields, array values (stored as JSON array string), and compound filter predicates; new `CustomConnectorResultProcessor` test component demonstrating post-processing of list values.

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
