### PR TITLE
chore: Bump jahia-parent from 3.6.0-SN to 4.0.0-SN

### DIFF
--- a/.github/workflows/on-code-change.yml
+++ b/.github/workflows/on-code-change.yml
@@ -32,7 +32,7 @@ jobs:
     needs: update-signature
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/jahia/jahia-docker-mvn-cache:8-jdk-noble-mvn-loaded
+      image: ghcr.io/jahia/jahia-docker-mvn-cache:11-jdk-noble-mvn-loaded
       credentials:
         username: ${{ secrets.GH_PACKAGES_USERNAME }}
         password: ${{ secrets.GH_PACKAGES_TOKEN }}
@@ -59,7 +59,7 @@ jobs:
           nexus_password: ${{ secrets.NEXUS_PASSWORD }}
 
   integration-tests:
-    uses:  Jahia/jahia-modules-action/.github/workflows/reusable-integration-tests.yml@v2
+    uses: Jahia/jahia-modules-action/.github/workflows/reusable-integration-tests.yml@v2
     needs: build
     secrets: inherit
     with:

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -6,9 +6,9 @@ name: On merge to master
 on:
   push:
     branches:
-      - 'master'
+      - "master"
     tags-ignore:
-      - '**'
+      - "**"
 
 jobs:
   update-signature:
@@ -31,7 +31,7 @@ jobs:
       NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
       NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
     container:
-      image: ghcr.io/jahia/jahia-docker-mvn-cache:8-jdk-noble-mvn-loaded
+      image: ghcr.io/jahia/jahia-docker-mvn-cache:11-jdk-noble-mvn-loaded
       credentials:
         username: ${{ secrets.GH_PACKAGES_USERNAME }}
         password: ${{ secrets.GH_PACKAGES_TOKEN }}
@@ -40,7 +40,7 @@ jobs:
       - uses: jahia/jahia-modules-action/build@v2
         with:
           module_id: jahia-oauth
-          mvn_settings_filepath: '.github/maven.settings.xml'
+          mvn_settings_filepath: ".github/maven.settings.xml"
 
   sbom:
     name: SBOM processing
@@ -53,7 +53,7 @@ jobs:
         with:
           dependencytrack_hostname: ${{ vars.DEPENDENCYTRACK_HOSTNAME }}
           dependencytrack_apikey: ${{ secrets.DEPENDENCYTRACK_APIKEY }}
-          sbom_artifacts: 'build-artifacts'
+          sbom_artifacts: "build-artifacts"
 
   publish:
     name: Publish module
@@ -63,7 +63,7 @@ jobs:
     env:
       NEXUS_INTERNAL_URL: https://devtools.jahia.com/nexus/content/groups/internal/
     container:
-      image: ghcr.io/jahia/jahia-docker-mvn-cache:8-jdk-noble-mvn-loaded
+      image: ghcr.io/jahia/jahia-docker-mvn-cache:11-jdk-noble-mvn-loaded
       credentials:
         username: ${{ secrets.GH_PACKAGES_USERNAME }}
         password: ${{ secrets.GH_PACKAGES_TOKEN }}
@@ -73,4 +73,4 @@ jobs:
         with:
           nexus_username: ${{ secrets.NEXUS_USERNAME }}
           nexus_password: ${{ secrets.NEXUS_PASSWORD }}
-          mvn_settings_filepath: '.github/maven.settings.xml'
+          mvn_settings_filepath: ".github/maven.settings.xml"

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -12,4 +12,4 @@ jobs:
     secrets: inherit
     with:
       primary_release_branch: "master"
-      job_container: "ghcr.io/jahia/jahia-docker-mvn-cache:8-jdk-noble-mvn-loaded"
+      job_container: "ghcr.io/jahia/jahia-docker-mvn-cache:11-jdk-noble-mvn-loaded"

--- a/.github/workflows/schedule-sonar.yml
+++ b/.github/workflows/schedule-sonar.yml
@@ -5,7 +5,7 @@ name: Sonar Analysis - Scheduled
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 4 * * 1,3,5' # At 4AM, on Monday, Wednesday and Friday
+    - cron: "0 4 * * 1,3,5" # At 4AM, on Monday, Wednesday and Friday
 
 env:
   MODULE_ID: jahia-oauth
@@ -17,9 +17,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-         supported_branches: ["${{ github.event.repository.default_branch }}"]
+        supported_branches: ["${{ github.event.repository.default_branch }}"]
     container:
-      image: ghcr.io/jahia/jahia-docker-mvn-cache:8-jdk-noble-mvn-loaded
+      image: ghcr.io/jahia/jahia-docker-mvn-cache:11-jdk-noble-mvn-loaded
       credentials:
         username: ${{ secrets.GH_PACKAGES_USERNAME }}
         password: ${{ secrets.GH_PACKAGES_TOKEN }}
@@ -32,13 +32,13 @@ jobs:
           nexus_username: ${{ secrets.NEXUS_USERNAME }}
           nexus_password: ${{ secrets.NEXUS_PASSWORD }}
           module_id: ${{ env.MODULE_ID }}
-          mvn_settings_filepath: '.github/maven.settings.xml'
+          mvn_settings_filepath: ".github/maven.settings.xml"
       - uses: jahia/jahia-modules-action/sonar-analysis@v2
         with:
           primary_release_branch: ${{ matrix.supported_branches }}
-          build_artifacts: ''
+          build_artifacts: ""
           github_pr_id: ${{github.event.number}}
           sonar_url: ${{ secrets.SONAR_URL }}
           sonar_token: ${{ secrets.SONAR_TOKEN }}
           nvd_apikey: ${{ secrets.NVD_APIKEY }}
-          mvn_settings_filepath: '.github/maven.settings.xml'
+          mvn_settings_filepath: ".github/maven.settings.xml"

--- a/pom.xml
+++ b/pom.xml
@@ -23,12 +23,12 @@
     <parent>
         <artifactId>jahia-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>8.0.1.0</version>
+        <version>8.2.0.0</version>
     </parent>
 
     <artifactId>jahia-oauth</artifactId>
     <name>Jahia OAuth</name>
-    <version>3.5.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <description>This is the custom module (Jahia OAuth) for running on a Digital Experience Manager server.</description>
 
@@ -45,7 +45,7 @@
         <jahia-static-resources>/css,/images,/javascript,/icons</jahia-static-resources>
         <require-capability>org.jahia.license;filter:="(key=org.jahia.oauthConnector)"</require-capability>
         <jahia-key>org.jahia.oauthConnector</jahia-key>
-        <jahia-module-signature>MCwCFHR7vORfumuFOb/7jQuUjnbk/5CXAhQfSNNynv5T6ujU4fsY6hVHuVYnxg==</jahia-module-signature>
+        <jahia-module-signature>MCwCFAYwKooy2abRYAmHAxYjjkIYCZ0jAhRc1fP4hGMk2VCOYEftmr3z7Ei3jw==</jahia-module-signature>
         <jahia.modules.importPackage>!com.hazelcast.config,!com.hazelcast.core</jahia.modules.importPackage>
         <sonar.sources>src/main/resources/javascript</sonar.sources>
     </properties>

--- a/tests/jahia-module/pom.xml
+++ b/tests/jahia-module/pom.xml
@@ -28,7 +28,7 @@
     <groupId>org.jahia.test</groupId>
     <artifactId>jahia-oauth-test-module</artifactId>
     <name>Test module for jahia-oauth</name>
-    <version>3.5.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
 
     <properties>

--- a/tests/jahia-module/pom.xml
+++ b/tests/jahia-module/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.jahia.modules</groupId>
             <artifactId>jahia-oauth</artifactId>
-            <version>3.4.0-SNAPSHOT</version>
+            <version>4.0.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/tests/jahia-module/pom.xml.versionsBackup
+++ b/tests/jahia-module/pom.xml.versionsBackup
@@ -28,7 +28,7 @@
     <groupId>org.jahia.test</groupId>
     <artifactId>jahia-oauth-test-module</artifactId>
     <name>Test module for jahia-oauth</name>
-    <version>3.4.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
 
     <properties>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.jahia.modules</groupId>
             <artifactId>jahia-oauth</artifactId>
-            <version>3.4.0-SNAPSHOT</version>
+            <version>4.0.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Considering the version bump (from 8.0.1.0 to 8.2.0.0) I decided to bump up the first digit.