### PR TITLE
chore: bump jackson from 2.12.0 to 2.21.4

### DIFF
--- a/.chachalog/NYzxQ3BM.md
+++ b/.chachalog/NYzxQ3BM.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+jahia-oauth: patch
+---
+
+Bump jackson from 2.12.0 to 2.21.4 (#156)

--- a/.chachalog/Zi3zyFp7.md
+++ b/.chachalog/Zi3zyFp7.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+jahia-oauth: patch
+---
+
+Bump jackson from 2.12.0 to 2.21.4 (#156)

--- a/.chachalog/Zi3zyFp7.md
+++ b/.chachalog/Zi3zyFp7.md
@@ -1,6 +1,0 @@
----
-# Allowed version bumps: patch, minor, major
-jahia-oauth: patch
----
-
-Bump jackson from 2.12.0 to 2.21.4 (#156)

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.12.0</version>
+            <version>2.21.4</version>
         </dependency>
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,11 @@
             <version>2.21.4</version>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.21.4</version>
+        </dependency>        
+        <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
             <version>2.10.0</version>


### PR DESCRIPTION
See parent ticket, to address CVEs.

See versioning policy: https://github.com/FasterXML/jackson/wiki/Jackson-Releases#general