### PR TITLE
ci: added manual trigger on merge workflow

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -4,6 +4,7 @@ name: On merge to main
 
 # The workflow could also be triggered on PRs
 on:
+  workflow_dispatch:
   push:
     branches:
       - 'main'


### PR DESCRIPTION
This should help address this failure: https://github.com/Jahia/jahia-oauth/actions/runs/26859154148/job/79208707335

Following the release, the snapshot version of the module wasn't published due to skip-ci tag.