### PR TITLE
chore: updated module version to 5.0.0 , adjusted dependency to jahia-authentication

### DIFF
--- a/.chachalog/_oYN4RY-.md
+++ b/.chachalog/_oYN4RY-.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+jahia-oauth: major
+---
+
+Updated the module to v5.0.0, compatible with Jahia 8.2.3.0+ and jahia-authentication 2.0.0+ (#165)

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -12,4 +12,3 @@ jobs:
     secrets: inherit
     with:
       primary_release_branch: "main"
-      job_container: "ghcr.io/jahia/jahia-docker-mvn-cache:11-jdk-noble-mvn-loaded"

--- a/pom.xml
+++ b/pom.xml
@@ -23,12 +23,12 @@
     <parent>
         <artifactId>jahia-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>8.2.0.0</version>
+        <version>8.2.3.0</version>
     </parent>
 
     <artifactId>jahia-oauth</artifactId>
     <name>Jahia OAuth</name>
-    <version>4.1.0-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <description>This is the custom module (Jahia OAuth) for running on a Digital Experience Manager server.</description>
 
@@ -45,7 +45,7 @@
         <jahia-static-resources>/css,/images,/javascript,/icons</jahia-static-resources>
         <require-capability>org.jahia.license;filter:="(key=org.jahia.oauthConnector)"</require-capability>
         <jahia-key>org.jahia.oauthConnector</jahia-key>
-        <jahia-module-signature>MCwCFFy4SJGi8CBcBn4M7PPKXbK1+gDpAhRqHzcwydAfaLraFaFTv26AYvBTRA==</jahia-module-signature>
+        <jahia-module-signature>MCwCFC5gwlow+su89HRf+FRFkwKDX4tnAhR79za9ZhIW/8QMfCbsmF8F/X6U9A==</jahia-module-signature>
         <jahia.modules.importPackage>!com.hazelcast.config,!com.hazelcast.core</jahia.modules.importPackage>
         <sonar.sources>src/main/resources/javascript</sonar.sources>
     </properties>
@@ -141,7 +141,7 @@
         <dependency>
             <groupId>org.jahia.modules</groupId>
             <artifactId>jahia-authentication</artifactId>
-            <version>1.7.0</version>
+            <version>2.0.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/tests/assets/dependencies.yml
+++ b/tests/assets/dependencies.yml
@@ -2,7 +2,7 @@
 # must use the deprecated 'installBundle' command while the target Jahia version is < 8.2.3.0 (where the 'installModule' command got added)
 - installBundle:
     # The range should include the jahia-authentication version defined in the pom.xml
-    - 'mvn:org.jahia.modules/jahia-authentication/[1.7,2.0-SNAPSHOT)'
+    - 'mvn:org.jahia.modules/jahia-authentication/[2.0-SNAPSHOT,3.0-SNAPSHOT)'    
     # Use the version range of jcr-auth-provider compatible with the jahia-authentication version above
     - 'mvn:org.jahia.modules/jcr-auth-provider/[3.0-SNAPSHOT,4.0-SNAPSHOT)'
   autoStart: true

--- a/tests/assets/dependencies.yml
+++ b/tests/assets/dependencies.yml
@@ -2,8 +2,8 @@
 # must use the deprecated 'installBundle' command while the target Jahia version is < 8.2.3.0 (where the 'installModule' command got added)
 - installBundle:
     # The range should include the jahia-authentication version defined in the pom.xml
-    - 'mvn:org.jahia.modules/jahia-authentication/[2.0-SNAPSHOT,3.0-SNAPSHOT)'    
+    - 'mvn:org.jahia.modules/jahia-authentication/[2.0-SNAPSHOT,3.0-SNAPSHOT)'
     # Use the version range of jcr-auth-provider compatible with the jahia-authentication version above
-    - 'mvn:org.jahia.modules/jcr-auth-provider/[3.0-SNAPSHOT,4.0-SNAPSHOT)'
+    - 'mvn:org.jahia.modules/jcr-auth-provider/[4.0-SNAPSHOT,5.0-SNAPSHOT)'
   autoStart: true
   uninstallPreviousVersion: true

--- a/tests/jahia-module/pom.xml
+++ b/tests/jahia-module/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>org.jahia.modules</groupId>
             <artifactId>jahia-oauth</artifactId>
-            <version>4.1.0-SNAPSHOT</version>
+            <version>5.0.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/tests/jahia-module/pom.xml
+++ b/tests/jahia-module/pom.xml
@@ -22,18 +22,17 @@
     <parent>
         <artifactId>jahia-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>8.0.1.0</version>
+        <version>8.2.3.0</version>
         <relativePath />
     </parent>
     <groupId>org.jahia.test</groupId>
     <artifactId>jahia-oauth-test-module</artifactId>
     <name>Test module for jahia-oauth</name>
-    <version>4.1.0-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
 
     <properties>
         <jahia-depends>jahia-oauth</jahia-depends>
-        <jahia.plugin.version>6.9</jahia.plugin.version>
     </properties>
 
     <dependencies>
@@ -46,7 +45,7 @@
         <dependency>
             <groupId>org.jahia.modules</groupId>
             <artifactId>jahia-authentication</artifactId>
-            <version>1.7.0</version>
+            <version>2.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
It is necessary to release a new version to be compatible with jahia-authentication 2.0.0.

See: https://github.com/Jahia/jcr-auth-provider/issues/77#issuecomment-4682117301