### PR TITLE
ci: fixed repositories

### DIFF
--- a/tests/jahia-module/pom.xml
+++ b/tests/jahia-module/pom.xml
@@ -35,6 +35,17 @@
         <jahia-depends>jahia-oauth</jahia-depends>
     </properties>
 
+    <distributionManagement>
+        <repository>
+            <id>oauth-releases</id>
+            <url>https://devtools.jahia.com/nexus/content/repositories/oauth-releases</url>
+        </repository>
+        <snapshotRepository>
+            <id>oauth-snapshots</id>
+            <url>https://devtools.jahia.com/nexus/content/repositories/oauth-snapshots</url>
+        </snapshotRepository>
+    </distributionManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.jahia.modules</groupId>
@@ -75,6 +86,32 @@
                 <enabled>true</enabled>
             </snapshots>
         </repository>
+        <repository>
+            <id>oauth-snapshots</id>
+            <name>Jahia OAuth Snapshots</name>
+            <url>https://devtools.jahia.com/nexus/content/repositories/oauth-snapshots/</url>
+            <releases>
+                <enabled>false</enabled>
+                <updatePolicy>never</updatePolicy>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>always</updatePolicy>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>oauth-releases</id>
+            <name>Jahia OAuth Releases</name>
+            <url>https://devtools.jahia.com/nexus/content/repositories/oauth-releases/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>never</updatePolicy>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+                <updatePolicy>always</updatePolicy>
+            </snapshots>
+        </repository>        
     </repositories>
 
     <build>


### PR DESCRIPTION
Fixed incorrect distribution setup for the tests module.

Goal being to fix this error during release:

> Error:  Failed to execute goal on project jahia-oauth-test-module: Could not resolve dependencies for project org.jahia.test:jahia-oauth-test-module:bundle:5.0.0
> Error:  dependency: org.jahia.modules:jahia-oauth:jar:5.0.0-SNAPSHOT (provided)
> Error:  	Could not find artifact org.jahia.modules:jahia-oauth:jar:5.0.0-SNAPSHOT in jahia-internal (https://devtools.jahia.com/nexus/content/groups/internal)
> Error:  	Could not find artifact org.jahia.modules:jahia-oauth:jar:5.0.0-SNAPSHOT in jahia-public (https://devtools.jahia.com/nexus/content/groups/public)
> Error:  -> [Help 1]
> Error:  
> Error:  To see the full stack trace of the errors, re-run Maven with the -e switch.
> Error:  Re-run Maven using the -X switch to enable full debug logging.
> Error:  
> Error:  For more information about the errors and possible solutions, please read the following articles:
> Error:  [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/DependencyResolutionException
> Error: Process completed with exit code 1.