### PR TITLE
fix: update version in test provisioning to fit with latest major version bump

### DIFF
--- a/tests/assets/snapshots.yml
+++ b/tests/assets/snapshots.yml
@@ -1,7 +1,7 @@
 # must use the deprecated 'installBundle' command while the target Jahia version is < 8.2.3.0 (where the 'installModule' command got added)
 - installBundle:
     # The range should match the current version of the module in the pom.xml
-    - 'mvn:org.jahia.modules/jahia-oauth/[4.0-SNAPSHOT,5.0-SNAPSHOT)'
-    - 'mvn:org.jahia.test/jahia-oauth-test-module/[4.0-SNAPSHOT,5.0-SNAPSHOT)'
+    - 'mvn:org.jahia.modules/jahia-oauth/[5.0-SNAPSHOT,6.0-SNAPSHOT)'
+    - 'mvn:org.jahia.test/jahia-oauth-test-module/[5.0-SNAPSHOT,6.0-SNAPSHOT)'
   autoStart: true
   uninstallPreviousVersion: true

--- a/tests/jahia-module/pom.xml
+++ b/tests/jahia-module/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.jahia.modules</groupId>
             <artifactId>jahia-oauth</artifactId>
-            <version>5.0.0-SNAPSHOT</version>
+            <version>5.1.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -111,7 +111,7 @@
                 <enabled>false</enabled>
                 <updatePolicy>always</updatePolicy>
             </snapshots>
-        </repository>        
+        </repository>
     </repositories>
 
     <build>


### PR DESCRIPTION
### Description

This pull request updates the version ranges and dependencies for the `jahia-oauth` module and its test module to use the latest 5.x snapshot versions. This ensures that the project is aligned with the most recent development versions and avoids compatibility issues with older versions.

Dependency and version updates:

* Updated the version range for `jahia-oauth` and `jahia-oauth-test-module` in `snapshots.yml` from `[4.0-SNAPSHOT,5.0-SNAPSHOT)` to `[5.0-SNAPSHOT,6.0-SNAPSHOT)` to target the latest 5.x snapshot versions.
* Updated the `jahia-oauth` dependency version in `jahia-module/pom.xml` from `5.0.0-SNAPSHOT` to `5.1.0-SNAPSHOT` to use the latest available snapshot.