### PR TITLE
chore: remove restrictive sonar.sources property

### DIFF
--- a/.github/workflows/schedule-sonar.yml
+++ b/.github/workflows/schedule-sonar.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        supported_branches: ["${{ github.event.repository.default_branch }}"]
+        supported_branches: ["wrong-sonar-limitation"]
     container:
       image: ghcr.io/jahia/jahia-docker-mvn-cache:11-jdk-noble-mvn-loaded
       credentials:

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
         <jahia-key>org.jahia.oauthConnector</jahia-key>
         <jahia-module-signature>MC0CFDSLz27DL+whEb1xHBAOtT2i2LYTAhUAhl5GLJgify5Bqf2z+mlsx0sq67A=</jahia-module-signature>
         <jahia.modules.importPackage>!com.hazelcast.config,!com.hazelcast.core</jahia.modules.importPackage>
+        <sonar.maven.scanAll>true</sonar.maven.scanAll>
     </properties>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,6 @@
         <jahia-key>org.jahia.oauthConnector</jahia-key>
         <jahia-module-signature>MC0CFDSLz27DL+whEb1xHBAOtT2i2LYTAhUAhl5GLJgify5Bqf2z+mlsx0sq67A=</jahia-module-signature>
         <jahia.modules.importPackage>!com.hazelcast.config,!com.hazelcast.core</jahia.modules.importPackage>
-        <sonar.sources>src/main/resources/javascript</sonar.sources>
     </properties>
 
     <distributionManagement>


### PR DESCRIPTION
### Description

Remove restrictive sonar.sources property, because it caused that Java sources were not checked.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
