### PR TITLE
fix: verify OAuth state and OIDC nonce (RFC 6749 §10.12 + OpenID Connect Core §3.1.3.7)

### DIFF
--- a/.chachalog/oauthStateVerification.md
+++ b/.chachalog/oauthStateVerification.md
@@ -2,4 +2,4 @@
 jahia-oauth: patch
 ---
 
-Harden the OAuth/OIDC login flow: issue an unpredictable, single-use `state` bound to the server-side session and verify it on the callback (RFC 6749 §10.12), instead of deriving it from the session id; and, when an OpenID Connect `nonce` is used, verify that the returned id_token carries the same value (OpenID Connect Core §3.1.3.7). The mapper cache remains keyed by the session id, so the SSO login flow is unchanged.
+Harden the OAuth/OIDC login flow: issue an unpredictable, single-use `state` and bind it (with the OIDC `nonce`) to the initiating session id in a cluster-wide store, verifying both on the callback (RFC 6749 §10.12 + OpenID Connect Core §3.1.3.7) instead of deriving the state from the session id. The callback recovers the values without relying on the HTTP session, and the mapper cache remains keyed by the session id, so the SSO login flow is unchanged.

--- a/.chachalog/oauthStateVerification.md
+++ b/.chachalog/oauthStateVerification.md
@@ -2,4 +2,4 @@
 jahia-oauth: patch
 ---
 
-Issue an unpredictable, single-use OAuth `state` bound to the server-side session and verify it on the callback (RFC 6749 §10.12), instead of deriving it from the session id. The mapper cache remains keyed by the session id, so the SSO login flow is unchanged.
+Harden the OAuth/OIDC login flow: issue an unpredictable, single-use `state` bound to the server-side session and verify it on the callback (RFC 6749 §10.12), instead of deriving it from the session id; and, when an OpenID Connect `nonce` is used, verify that the returned id_token carries the same value (OpenID Connect Core §3.1.3.7). The mapper cache remains keyed by the session id, so the SSO login flow is unchanged.

--- a/.chachalog/oauthStateVerification.md
+++ b/.chachalog/oauthStateVerification.md
@@ -1,0 +1,5 @@
+---
+jahia-oauth: patch
+---
+
+Issue an unpredictable, single-use OAuth `state` bound to the server-side session and verify it on the callback (RFC 6749 §10.12), instead of deriving it from the session id. The mapper cache remains keyed by the session id, so the SSO login flow is unchanged.

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
         <dependency>
             <groupId>org.jahia.modules</groupId>
             <artifactId>jahia-authentication</artifactId>
-            <version>2.0.0</version>
+            <version>2.1.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/org/jahia/modules/jahiaoauth/action/ConnectToOAuthProvider.java
+++ b/src/main/java/org/jahia/modules/jahiaoauth/action/ConnectToOAuthProvider.java
@@ -58,7 +58,14 @@ public class ConnectToOAuthProvider extends Action {
 
         ConnectorConfig oauthConfig = settingsService.getConnectorConfig(renderContext.getSite().getSiteKey(), connectorName);
 
-        String authorizationUrl = jahiaOAuthService.getAuthorizationUrl(oauthConfig, state, getAdditionalParams());
+        // When an OIDC nonce is included in the authorization request, bind it to the session so the
+        // callback can verify the id_token carries the same value (OpenID Connect Core §3.1.2.1).
+        Map<String, String> additionalParams = getAdditionalParams();
+        if (additionalParams != null && additionalParams.containsKey(JahiaOAuthConstants.NONCE)) {
+            req.getSession().setAttribute(JahiaOAuthConstants.SESSION_OAUTH_NONCE, additionalParams.get(JahiaOAuthConstants.NONCE));
+        }
+
+        String authorizationUrl = jahiaOAuthService.getAuthorizationUrl(oauthConfig, state, additionalParams);
         JSONObject response = new JSONObject();
         response.put(JahiaOAuthConstants.AUTHORIZATION_URL, authorizationUrl);
         return new ActionResult(HttpServletResponse.SC_OK, null, response);

--- a/src/main/java/org/jahia/modules/jahiaoauth/action/ConnectToOAuthProvider.java
+++ b/src/main/java/org/jahia/modules/jahiaoauth/action/ConnectToOAuthProvider.java
@@ -49,21 +49,18 @@ public class ConnectToOAuthProvider extends Action {
     public ActionResult doExecute(HttpServletRequest req, RenderContext renderContext, Resource resource, JCRSessionWrapper session,
             Map<String, List<String>> parameters, URLResolver urlResolver) throws Exception {
 
-        // Issue an unpredictable, single-use state value and bind it to the server-side session
-        // (RFC 6749 §10.12), rather than deriving the state from the session id. OAuthCallback checks
-        // and consumes it; the mapper cache there remains keyed by the session id, so the SSO flow is
-        // unchanged.
+        // Issue an unpredictable, single-use state value instead of deriving it from the session id
+        // (RFC 6749 §10.12). Bind the state (and the OIDC nonce, if any) to the initiating session id in
+        // a cluster-wide store, so the callback can recover and verify them without depending on the HTTP
+        // session being available on the callback's node. OAuthCallback consumes and checks the state; the
+        // mapper cache there is keyed by the recovered session id, so the SSO flow is unchanged.
         final String state = new BigInteger(130, SECURE_RANDOM).toString(32);
-        req.getSession().setAttribute(JahiaOAuthConstants.SESSION_OAUTH_STATE, state);
 
         ConnectorConfig oauthConfig = settingsService.getConnectorConfig(renderContext.getSite().getSiteKey(), connectorName);
 
-        // When an OIDC nonce is included in the authorization request, bind it to the session so the
-        // callback can verify the id_token carries the same value (OpenID Connect Core §3.1.2.1).
         Map<String, String> additionalParams = getAdditionalParams();
-        if (additionalParams != null && additionalParams.containsKey(JahiaOAuthConstants.NONCE)) {
-            req.getSession().setAttribute(JahiaOAuthConstants.SESSION_OAUTH_NONCE, additionalParams.get(JahiaOAuthConstants.NONCE));
-        }
+        String nonce = additionalParams != null ? additionalParams.get(JahiaOAuthConstants.NONCE) : null;
+        jahiaOAuthService.cacheAuthorizationFlowState(state, req.getSession().getId(), nonce);
 
         String authorizationUrl = jahiaOAuthService.getAuthorizationUrl(oauthConfig, state, additionalParams);
         JSONObject response = new JSONObject();

--- a/src/main/java/org/jahia/modules/jahiaoauth/action/ConnectToOAuthProvider.java
+++ b/src/main/java/org/jahia/modules/jahiaoauth/action/ConnectToOAuthProvider.java
@@ -29,6 +29,8 @@ import org.json.JSONObject;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.math.BigInteger;
+import java.security.SecureRandom;
 import java.util.List;
 import java.util.Map;
 
@@ -36,6 +38,8 @@ import java.util.Map;
  * @author dgaillard
  */
 public class ConnectToOAuthProvider extends Action {
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
     private SettingsService settingsService;
     private JahiaOAuthService jahiaOAuthService;
     private String connectorName;
@@ -45,11 +49,16 @@ public class ConnectToOAuthProvider extends Action {
     public ActionResult doExecute(HttpServletRequest req, RenderContext renderContext, Resource resource, JCRSessionWrapper session,
             Map<String, List<String>> parameters, URLResolver urlResolver) throws Exception {
 
-        final String sessionId = req.getSession().getId();
+        // Issue an unpredictable, single-use state value and bind it to the server-side session
+        // (RFC 6749 §10.12), rather than deriving the state from the session id. OAuthCallback checks
+        // and consumes it; the mapper cache there remains keyed by the session id, so the SSO flow is
+        // unchanged.
+        final String state = new BigInteger(130, SECURE_RANDOM).toString(32);
+        req.getSession().setAttribute(JahiaOAuthConstants.SESSION_OAUTH_STATE, state);
 
         ConnectorConfig oauthConfig = settingsService.getConnectorConfig(renderContext.getSite().getSiteKey(), connectorName);
 
-        String authorizationUrl = jahiaOAuthService.getAuthorizationUrl(oauthConfig, sessionId, getAdditionalParams());
+        String authorizationUrl = jahiaOAuthService.getAuthorizationUrl(oauthConfig, state, getAdditionalParams());
         JSONObject response = new JSONObject();
         response.put(JahiaOAuthConstants.AUTHORIZATION_URL, authorizationUrl);
         return new ActionResult(HttpServletResponse.SC_OK, null, response);

--- a/src/main/java/org/jahia/modules/jahiaoauth/action/OAuthCallback.java
+++ b/src/main/java/org/jahia/modules/jahiaoauth/action/OAuthCallback.java
@@ -68,10 +68,14 @@ public class OAuthCallback extends Action {
             }
             String siteKey = renderContext.getSite().getSiteKey();
             ConnectorConfig oauthConfig = settingsService.getConnectorConfig(siteKey, connectorName);
+            final Object expectedNonce = req.getSession().getAttribute(JahiaOAuthConstants.SESSION_OAUTH_NONCE);
+            req.getSession().removeAttribute(JahiaOAuthConstants.SESSION_OAUTH_NONCE);
             try {
                 // The mapper cache is keyed by the session id (consumed by the SSO valve), decoupled
-                // from the state value above.
-                jahiaOAuthService.extractAccessTokenAndExecuteMappers(oauthConfig, token, req.getSession().getId());
+                // from the state value above. When an OIDC nonce was issued it is verified against the
+                // returned id_token.
+                jahiaOAuthService.extractAccessTokenAndExecuteMappers(oauthConfig, token, req.getSession().getId(),
+                        expectedNonce != null ? expectedNonce.toString() : null);
                 isAuthenticate = true;
             } catch (Exception ex) {
                 logger.error("Could not authenticate user", ex);

--- a/src/main/java/org/jahia/modules/jahiaoauth/action/OAuthCallback.java
+++ b/src/main/java/org/jahia/modules/jahiaoauth/action/OAuthCallback.java
@@ -22,6 +22,7 @@ import org.jahia.modules.jahiaauth.service.ConnectorConfig;
 import org.jahia.modules.jahiaauth.service.SettingsService;
 import org.jahia.modules.jahiaoauth.service.JahiaOAuthConstants;
 import org.jahia.modules.jahiaoauth.service.JahiaOAuthService;
+import org.jahia.modules.jahiaoauth.service.OAuthFlowState;
 import org.jahia.services.content.JCRSessionWrapper;
 import org.jahia.services.render.RenderContext;
 import org.jahia.services.render.Resource;
@@ -31,8 +32,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
 import java.util.List;
 import java.util.Map;
 
@@ -57,25 +56,21 @@ public class OAuthCallback extends Action {
             if (StringUtils.isBlank(token) || StringUtils.isBlank(state)) {
                 return ActionResult.BAD_REQUEST;
             }
-            // Verify the returned state matches the single-use value issued for this session at
-            // initiation, then consume it (RFC 6749 §10.12). Constant-time comparison.
-            final Object expectedState = req.getSession().getAttribute(JahiaOAuthConstants.SESSION_OAUTH_STATE);
-            req.getSession().removeAttribute(JahiaOAuthConstants.SESSION_OAUTH_STATE);
-            if (expectedState == null || !MessageDigest.isEqual(
-                    expectedState.toString().getBytes(StandardCharsets.UTF_8), state.getBytes(StandardCharsets.UTF_8))) {
-                logger.warn("OAuth callback rejected: state parameter does not match the value issued for this session");
+            // Recover and consume the flow state bound to this state token at initiation (cluster-wide
+            // store). A missing entry means the state is unknown, already used or expired -> reject
+            // (RFC 6749 §10.12). This does not rely on the HTTP session being present on this node.
+            OAuthFlowState flowState = jahiaOAuthService.consumeAuthorizationFlowState(state);
+            if (flowState == null) {
+                logger.warn("OAuth callback rejected: unknown, already-used or expired state");
                 return ActionResult.BAD_REQUEST;
             }
             String siteKey = renderContext.getSite().getSiteKey();
             ConnectorConfig oauthConfig = settingsService.getConnectorConfig(siteKey, connectorName);
-            final Object expectedNonce = req.getSession().getAttribute(JahiaOAuthConstants.SESSION_OAUTH_NONCE);
-            req.getSession().removeAttribute(JahiaOAuthConstants.SESSION_OAUTH_NONCE);
             try {
-                // The mapper cache is keyed by the session id (consumed by the SSO valve), decoupled
-                // from the state value above. When an OIDC nonce was issued it is verified against the
-                // returned id_token.
-                jahiaOAuthService.extractAccessTokenAndExecuteMappers(oauthConfig, token, req.getSession().getId(),
-                        expectedNonce != null ? expectedNonce.toString() : null);
+                // The mapper cache is keyed by the initiating session id recovered from the flow state
+                // (consumed by the SSO valve). The OIDC nonce (if any) is verified against the id_token.
+                jahiaOAuthService.extractAccessTokenAndExecuteMappers(oauthConfig, token,
+                        flowState.getSessionId(), flowState.getNonce());
                 isAuthenticate = true;
             } catch (Exception ex) {
                 logger.error("Could not authenticate user", ex);

--- a/src/main/java/org/jahia/modules/jahiaoauth/action/OAuthCallback.java
+++ b/src/main/java/org/jahia/modules/jahiaoauth/action/OAuthCallback.java
@@ -31,6 +31,8 @@ import org.slf4j.LoggerFactory;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.util.List;
 import java.util.Map;
 
@@ -55,10 +57,21 @@ public class OAuthCallback extends Action {
             if (StringUtils.isBlank(token) || StringUtils.isBlank(state)) {
                 return ActionResult.BAD_REQUEST;
             }
+            // Verify the returned state matches the single-use value issued for this session at
+            // initiation, then consume it (RFC 6749 §10.12). Constant-time comparison.
+            final Object expectedState = req.getSession().getAttribute(JahiaOAuthConstants.SESSION_OAUTH_STATE);
+            req.getSession().removeAttribute(JahiaOAuthConstants.SESSION_OAUTH_STATE);
+            if (expectedState == null || !MessageDigest.isEqual(
+                    expectedState.toString().getBytes(StandardCharsets.UTF_8), state.getBytes(StandardCharsets.UTF_8))) {
+                logger.warn("OAuth callback rejected: state parameter does not match the value issued for this session");
+                return ActionResult.BAD_REQUEST;
+            }
             String siteKey = renderContext.getSite().getSiteKey();
             ConnectorConfig oauthConfig = settingsService.getConnectorConfig(siteKey, connectorName);
             try {
-                jahiaOAuthService.extractAccessTokenAndExecuteMappers(oauthConfig, token, state);
+                // The mapper cache is keyed by the session id (consumed by the SSO valve), decoupled
+                // from the state value above.
+                jahiaOAuthService.extractAccessTokenAndExecuteMappers(oauthConfig, token, req.getSession().getId());
                 isAuthenticate = true;
             } catch (Exception ex) {
                 logger.error("Could not authenticate user", ex);

--- a/src/main/java/org/jahia/modules/jahiaoauth/impl/JahiaOAuthServiceImpl.java
+++ b/src/main/java/org/jahia/modules/jahiaoauth/impl/JahiaOAuthServiceImpl.java
@@ -60,6 +60,8 @@ import java.util.concurrent.ConcurrentHashMap;
 public class JahiaOAuthServiceImpl implements JahiaOAuthService {
     private static final Logger logger = LoggerFactory.getLogger(JahiaOAuthServiceImpl.class);
     private static final Configuration JSONPATH_CONFIG = Configuration.builder().build();
+    private static final String FLOW_STATE_KEY_PREFIX = "oauth_";
+    private static final String FLOW_SESSION_ID = "sessionId";
 
     private final Map<String, JahiaOAuthAPIBuilder> oAuthDefaultApi20Map;
 
@@ -212,6 +214,33 @@ public class JahiaOAuthServiceImpl implements JahiaOAuthService {
         } catch (Exception e) {
             throw new JahiaOAuthException("Something when wrong in OAuth with config " + config.getConnectorName(), e);
         }
+    }
+
+    @Override
+    public void cacheAuthorizationFlowState(String state, String sessionId, String nonce) {
+        JSONObject json = new JSONObject();
+        json.put(FLOW_SESSION_ID, sessionId);
+        if (nonce != null) {
+            json.put(JahiaOAuthConstants.NONCE, nonce);
+        }
+        jahiaAuthMapperService.cacheValue(FLOW_STATE_KEY_PREFIX + state, json.toString());
+    }
+
+    @Override
+    public OAuthFlowState consumeAuthorizationFlowState(String state) {
+        if (StringUtils.isBlank(state)) {
+            return null;
+        }
+        String cacheKey = FLOW_STATE_KEY_PREFIX + state;
+        String value = jahiaAuthMapperService.getCachedValue(cacheKey);
+        if (value == null) {
+            return null;
+        }
+        // Single-use: consume before proceeding.
+        jahiaAuthMapperService.invalidate(cacheKey);
+        JSONObject json = new JSONObject(value);
+        return new OAuthFlowState(json.optString(FLOW_SESSION_ID, null),
+                json.has(JahiaOAuthConstants.NONCE) ? json.optString(JahiaOAuthConstants.NONCE, null) : null);
     }
 
     private void verifyIdTokenNonce(OAuth2AccessToken accessToken, String expectedNonce) throws JahiaOAuthException {

--- a/src/main/java/org/jahia/modules/jahiaoauth/impl/JahiaOAuthServiceImpl.java
+++ b/src/main/java/org/jahia/modules/jahiaoauth/impl/JahiaOAuthServiceImpl.java
@@ -27,6 +27,9 @@ import com.github.scribejava.core.oauth.OAuth20Service;
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.JsonPath;
 import org.apache.commons.lang.StringUtils;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Base64;
 import org.jahia.modules.jahiaauth.service.*;
 import org.jahia.modules.jahiaoauth.service.*;
 import org.jahia.modules.scribejava.apis.FranceConnectApi;
@@ -130,10 +133,21 @@ public class JahiaOAuthServiceImpl implements JahiaOAuthService {
     }
 
     @Override
-    @SuppressWarnings("java:S3776")
     public void extractAccessTokenAndExecuteMappers(ConnectorConfig config, String token, String state) throws Exception {
+        extractAccessTokenAndExecuteMappers(config, token, state, null);
+    }
+
+    @Override
+    @SuppressWarnings("java:S3776")
+    public void extractAccessTokenAndExecuteMappers(ConnectorConfig config, String token, String state, String expectedNonce) throws Exception {
         OAuth20Service service = createOAuth20Service(config);
         OAuth2AccessToken accessToken = service.getAccessToken(token);
+
+        // OpenID Connect: when a nonce was issued at initiation, the returned id_token must carry the
+        // same value (OpenID Connect Core §3.1.3.7). Verified here before the identity is used.
+        if (expectedNonce != null) {
+            verifyIdTokenNonce(accessToken, expectedNonce);
+        }
 
         OAuthConnectorService connectorService = BundleUtils.getOsgiService(OAuthConnectorService.class,
                 "(" + JahiaAuthConstants.CONNECTOR_SERVICE_NAME + "=" + config.getConnectorName() + ")");
@@ -197,6 +211,31 @@ public class JahiaOAuthServiceImpl implements JahiaOAuthService {
             jahiaAuthMapperService.executeConnectorResultProcessors(config, propertiesResult);
         } catch (Exception e) {
             throw new JahiaOAuthException("Something when wrong in OAuth with config " + config.getConnectorName(), e);
+        }
+    }
+
+    private void verifyIdTokenNonce(OAuth2AccessToken accessToken, String expectedNonce) throws JahiaOAuthException {
+        if (!(accessToken instanceof OpenIdOAuth2AccessToken)) {
+            throw new JahiaOAuthException("A nonce was issued for this flow but the provider returned no OpenID Connect id_token to verify it against");
+        }
+        String idToken = ((OpenIdOAuth2AccessToken) accessToken).getOpenIdToken();
+        if (StringUtils.isBlank(idToken)) {
+            throw new JahiaOAuthException("A nonce was issued for this flow but the id_token is missing; cannot verify the nonce");
+        }
+        String[] parts = idToken.split("\\.");
+        if (parts.length < 2) {
+            throw new JahiaOAuthException("Malformed id_token; cannot verify the nonce");
+        }
+        String actualNonce;
+        try {
+            String payloadJson = new String(Base64.getUrlDecoder().decode(parts[1]), StandardCharsets.UTF_8);
+            actualNonce = new JSONObject(payloadJson).optString(JahiaOAuthConstants.NONCE, null);
+        } catch (RuntimeException e) {
+            throw new JahiaOAuthException("Could not read the nonce claim from the id_token", e);
+        }
+        if (actualNonce == null || !MessageDigest.isEqual(
+                actualNonce.getBytes(StandardCharsets.UTF_8), expectedNonce.getBytes(StandardCharsets.UTF_8))) {
+            throw new JahiaOAuthException("The id_token nonce does not match the value sent in the authorization request");
         }
     }
 

--- a/src/main/java/org/jahia/modules/jahiaoauth/service/JahiaOAuthConstants.java
+++ b/src/main/java/org/jahia/modules/jahiaoauth/service/JahiaOAuthConstants.java
@@ -27,6 +27,8 @@ public class JahiaOAuthConstants {
     public static final String PROPERTY_SCOPE = "scope";
 
     public static final String STATE = "state";
+    /** Session attribute holding the single-use OAuth {@code state} issued at initiation, verified on callback. */
+    public static final String SESSION_OAUTH_STATE = "org.jahia.modules.jahiaoauth.state";
     public static final String TOKEN_DATA = "tokenData";
     public static final String ACCESS_TOKEN = "accessToken";
     public static final String TOKEN_EXPIRES_IN = "expiresIn";

--- a/src/main/java/org/jahia/modules/jahiaoauth/service/JahiaOAuthConstants.java
+++ b/src/main/java/org/jahia/modules/jahiaoauth/service/JahiaOAuthConstants.java
@@ -29,6 +29,9 @@ public class JahiaOAuthConstants {
     public static final String STATE = "state";
     /** Session attribute holding the single-use OAuth {@code state} issued at initiation, verified on callback. */
     public static final String SESSION_OAUTH_STATE = "org.jahia.modules.jahiaoauth.state";
+    /** Session attribute holding the OIDC {@code nonce} sent at initiation, verified against the id_token on callback. */
+    public static final String SESSION_OAUTH_NONCE = "org.jahia.modules.jahiaoauth.nonce";
+    public static final String NONCE = "nonce";
     public static final String TOKEN_DATA = "tokenData";
     public static final String ACCESS_TOKEN = "accessToken";
     public static final String TOKEN_EXPIRES_IN = "expiresIn";

--- a/src/main/java/org/jahia/modules/jahiaoauth/service/JahiaOAuthConstants.java
+++ b/src/main/java/org/jahia/modules/jahiaoauth/service/JahiaOAuthConstants.java
@@ -27,10 +27,6 @@ public class JahiaOAuthConstants {
     public static final String PROPERTY_SCOPE = "scope";
 
     public static final String STATE = "state";
-    /** Session attribute holding the single-use OAuth {@code state} issued at initiation, verified on callback. */
-    public static final String SESSION_OAUTH_STATE = "org.jahia.modules.jahiaoauth.state";
-    /** Session attribute holding the OIDC {@code nonce} sent at initiation, verified against the id_token on callback. */
-    public static final String SESSION_OAUTH_NONCE = "org.jahia.modules.jahiaoauth.nonce";
     public static final String NONCE = "nonce";
     public static final String TOKEN_DATA = "tokenData";
     public static final String ACCESS_TOKEN = "accessToken";

--- a/src/main/java/org/jahia/modules/jahiaoauth/service/JahiaOAuthService.java
+++ b/src/main/java/org/jahia/modules/jahiaoauth/service/JahiaOAuthService.java
@@ -51,10 +51,22 @@ public interface JahiaOAuthService {
      *
      * @param config The oauth config for the connector
      * @param token  String token send by the OAuth API
-     * @param state  String state send back by OAuth API in this context it's the user session ID
+     * @param state  String cache key linking the result to the initiating session (the session id)
      * @throws Exception
      */
     void extractAccessTokenAndExecuteMappers(ConnectorConfig config, String token, String state) throws Exception;
+
+    /**
+     * Same as {@link #extractAccessTokenAndExecuteMappers(ConnectorConfig, String, String)}, additionally
+     * verifying that the returned OIDC id_token carries the {@code nonce} sent in the authorization request.
+     *
+     * @param config        The oauth config for the connector
+     * @param token         String token send by the OAuth API
+     * @param state         String cache key linking the result to the initiating session (the session id)
+     * @param expectedNonce The nonce issued at initiation, or {@code null} to skip the check (non-OIDC flow)
+     * @throws Exception if the token exchange fails or the id_token nonce does not match
+     */
+    void extractAccessTokenAndExecuteMappers(ConnectorConfig config, String token, String state, String expectedNonce) throws Exception;
 
     /**
      * This method will return the URL of the result page so the user can be inform of the succes or not of his authentication

--- a/src/main/java/org/jahia/modules/jahiaoauth/service/JahiaOAuthService.java
+++ b/src/main/java/org/jahia/modules/jahiaoauth/service/JahiaOAuthService.java
@@ -69,6 +69,26 @@ public interface JahiaOAuthService {
     void extractAccessTokenAndExecuteMappers(ConnectorConfig config, String token, String state, String expectedNonce) throws Exception;
 
     /**
+     * Bind an unpredictable authorization-flow {@code state} token to the initiating session id (and an
+     * optional OIDC nonce) in a cluster-wide, short-lived store. The callback recovers these via
+     * {@link #consumeAuthorizationFlowState(String)} without relying on the HTTP session being available
+     * on the callback's node.
+     *
+     * @param state     the single-use state token sent in the authorization request
+     * @param sessionId the id of the session initiating the flow (used later as the mapper-cache key)
+     * @param nonce     the OIDC nonce sent in the authorization request, or {@code null}
+     */
+    void cacheAuthorizationFlowState(String state, String sessionId, String nonce);
+
+    /**
+     * Look up and consume (single-use) the flow state bound to a callback's {@code state} token.
+     *
+     * @param state the state returned on the callback
+     * @return the bound {@link OAuthFlowState}, or {@code null} if the state is unknown, already consumed or expired
+     */
+    OAuthFlowState consumeAuthorizationFlowState(String state);
+
+    /**
      * This method will return the URL of the result page so the user can be inform of the succes or not of his authentication
      *
      * @param siteUrl        String current site URL

--- a/src/main/java/org/jahia/modules/jahiaoauth/service/OAuthFlowState.java
+++ b/src/main/java/org/jahia/modules/jahiaoauth/service/OAuthFlowState.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2002-2025 Jahia Solutions Group SA. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jahia.modules.jahiaoauth.service;
+
+/**
+ * The values bound to a single authorization-flow {@code state} token at initiation, recovered on the
+ * callback from the cluster-wide flow-state cache. Lets the callback resolve the initiating session id
+ * (the mapper-cache key) and the OIDC nonce without relying on the HTTP session being present.
+ */
+public final class OAuthFlowState {
+    private final String sessionId;
+    private final String nonce;
+
+    public OAuthFlowState(String sessionId, String nonce) {
+        this.sessionId = sessionId;
+        this.nonce = nonce;
+    }
+
+    /** The id of the session that initiated the flow; used as the mapper-cache key. */
+    public String getSessionId() {
+        return sessionId;
+    }
+
+    /** The OIDC nonce sent at initiation, or {@code null} for a non-OIDC flow. */
+    public String getNonce() {
+        return nonce;
+    }
+}


### PR DESCRIPTION
### What
The OAuth/OIDC login flow (1) used the HTTP **session id as the `state`** and never verified the `state` returned on the callback, and (2) generated an OIDC **`nonce`**, sent it, but never verified it against the id_token.

### Change
- **State (RFC 6749 §10.12):** `ConnectToOAuthProvider` issues a `SecureRandom` single-use `state` and binds `{sessionId, nonce}` to it in a **cluster-wide flow-state store**; `OAuthCallback` consumes it (single-use) and rejects an unknown/expired/replayed state.
- **Nonce (OIDC Core §3.1.3.7):** the returned id_token's `nonce` claim is verified against the bound value (new 4-arg `extractAccessTokenAndExecuteMappers` overload; 3-arg delegates).
- The mapper cache stays keyed by the **initiating session id** (recovered from the flow store), so the SSO valve lookup is unchanged.

### Why the cluster-wide store (not the HTTP session)
The OAuth callback is a cross-site redirect that can land on a **different cluster node** than the initiating request; whether the HTTP session is present there depends on HTTP-session replication (the optional `distributed-sessions` module) or load-balancer stickiness surviving the cross-site navigation — neither of which this module otherwise relies on (it carries the **session-id string** and rendezvouses through a distributed cache). So the state/nonce are stored the same way: bound to the session-id string in a cluster-wide store, recovered by the state token from the URL. Correct on a single node **and** in clusters with or without distributed-sessions/stickiness. Fails closed if the state is unknown.

### Dependency
Uses the new flow-state API added in **[jahia-authentication#98](https://github.com/Jahia/jahia-authentication/pull/98)** — dependency bumped to `2.1.0`. **This PR's CI build needs jahia-authentication `2.1.0` released first** (#98 must merge + release). Both modules compile locally against each other.

Draft — opening for CI + a reviewer OAuth/OIDC round-trip smoke test (incl. a clustered / no-distributed-sessions setup). Full id_token *signature* validation remains a separate follow-up.