### PR TITLE
fix: emit the oauth-result authentication flag as a boolean literal

### DIFF
--- a/.chachalog/9LVtr7.md
+++ b/.chachalog/9LVtr7.md
@@ -1,0 +1,5 @@
+---
+jahia-oauth: patch
+---
+
+Emit the oauth-result authentication flag as a boolean literal

--- a/src/main/resources/joant_oauthResult/html/oauthResult.jsp
+++ b/src/main/resources/joant_oauthResult/html/oauthResult.jsp
@@ -26,7 +26,7 @@
         <template:addResources>
             <script>
                 (function() {
-                    window.opener.postMessage({authenticationIsDone: true, isAuthenticate: ${param.isAuthenticate}}, '*');
+                    window.opener.postMessage({authenticationIsDone: true, isAuthenticate: ${param.isAuthenticate eq 'true'}}, '*');
 
                     <c:if test="${param.isAuthenticate eq true}">
                         console.log('This window will be closed in 3 sec');

--- a/tests/cypress/e2e/oauthResultFlag.cy.ts
+++ b/tests/cypress/e2e/oauthResultFlag.cy.ts
@@ -1,0 +1,56 @@
+import {createSite, deleteSite, enableModule, publishAndWaitJobEnding} from '@jahia/cypress';
+import {faker} from '@faker-js/faker';
+
+/**
+ * The oauth-result view echoes the `isAuthenticate` request flag into an inline script that
+ * calls window.opener.postMessage(...). That flag is only ever meaningfully true or false, so
+ * the emitted token must be a well-formed boolean literal — never the raw request value dropped
+ * verbatim into the script. These specs pin that contract at the live render layer.
+ */
+describe('oauth-result view — isAuthenticate flag rendering', () => {
+    let siteKey: string;
+
+    const resultUrl = (value: string): string =>
+        `/cms/render/live/en/sites/${siteKey}/oauth-result.html?isAuthenticate=${encodeURIComponent(value)}`;
+
+    beforeEach(() => {
+        siteKey = faker.lorem.slug();
+        createSite(siteKey, {
+            locale: 'en',
+            serverName: 'localhost',
+            templateSet: 'jahia-oauth-test-module'
+        });
+        publishAndWaitJobEnding(`/sites/${siteKey}`);
+        enableModule('jahia-oauth', siteKey);
+        cy.logout();
+    });
+
+    afterEach(() => {
+        deleteSite(siteKey);
+    });
+
+    it('normalises a stray flag value to a boolean literal', () => {
+        // A value that is not a clean boolean must not survive into the inline script verbatim.
+        const stray = '</scr' + 'ipt><script>window.__resultProbe__=1</scr' + 'ipt><script>//';
+
+        cy.request(resultUrl(stray)).its('body').then((body: string) => {
+            // The flag is rendered as a boolean literal in the postMessage payload...
+            expect(body).to.match(/isAuthenticate:\s*(true|false)\b/);
+            // ...and the stray value never surfaces as active markup or a bare token.
+            expect(body).not.to.contain('window.__resultProbe__');
+            expect(body).not.to.contain('</scr' + 'ipt><script>');
+        });
+    });
+
+    it('still reports a genuine successful result as true', () => {
+        cy.request(resultUrl('true')).its('body').then((body: string) => {
+            expect(body).to.contain('isAuthenticate: true');
+        });
+    });
+
+    it('reports a non-success result as false', () => {
+        cy.request(resultUrl('false')).its('body').then((body: string) => {
+            expect(body).to.contain('isAuthenticate: false');
+        });
+    });
+});


### PR DESCRIPTION
## Summary

The `joant:oauthResult` view drops the `isAuthenticate` result flag straight into its inline
`postMessage` script as a bare, unquoted token. Because the value is written verbatim, anything
other than a clean `true`/`false` produces a malformed script fragment rather than the boolean the
rest of the view expects. This makes the emitted value a well-formed boolean literal, consistent
with how the flag is already evaluated in the same view.

## Change

- `joant_oauthResult/html/oauthResult.jsp` — emit the flag as a boolean expression
  `${param.isAuthenticate eq 'true'}` so the token written into the inline `postMessage` object is
  always a valid `true` or `false` literal. This mirrors the boolean tests the same view already
  uses for `isAuthenticate` (the `${param.isAuthenticate eq true}` guard and the
  `${param.isAuthenticate}` branch condition), keeping the three uses of the flag consistent.

No behavior change on the normal success/error result flows: a request carrying `isAuthenticate=true`
still emits `true`, and the error/absent case still emits `false`.

## Verification

- Built the module (`mvn clean install`) and deployed it to a local Jahia; the
  `joant:oauthResult` bundle reaches **ACTIVE**.
- Rendered the `joant:oauthResult` component in live mode with a range of `isAuthenticate` values.
  The inline script now always emits `isAuthenticate: true` or `isAuthenticate: false` — never the
  raw request value — so the object passed to `postMessage` is always well-formed.
- Legitimate success (`isAuthenticate=true`) and error (`isAuthenticate=false` / absent) results
  render and behave exactly as before.
- Ships a regression spec that renders the view with an unexpected flag value and asserts the
  emitted line is a boolean literal (fails on the previous behavior, passes with this change).
