### PR TITLE
fix: emit the OAuth result authentication flag as a well-formed boolean

### DIFF
--- a/.chachalog/r7nVWv99.md
+++ b/.chachalog/r7nVWv99.md
@@ -1,0 +1,5 @@
+---
+jahia-oauth: patch
+---
+
+Emit the OAuth result authentication flag as a well-formed boolean and post it to the page origin

--- a/src/main/resources/joant_oauthResult/html/oauthResult.jsp
+++ b/src/main/resources/joant_oauthResult/html/oauthResult.jsp
@@ -26,7 +26,7 @@
         <template:addResources>
             <script>
                 (function() {
-                    window.opener.postMessage({authenticationIsDone: true, isAuthenticate: ${param.isAuthenticate}}, '*');
+                    window.opener.postMessage({authenticationIsDone: true, isAuthenticate: ${param.isAuthenticate eq 'true'}}, window.location.origin);
 
                     <c:if test="${param.isAuthenticate eq true}">
                         console.log('This window will be closed in 3 sec');

--- a/tests/cypress/e2e/oauthResult.cy.ts
+++ b/tests/cypress/e2e/oauthResult.cy.ts
@@ -1,0 +1,66 @@
+import {
+    createSite,
+    deleteSite,
+    enableModule,
+    publishAndWaitJobEnding
+} from '@jahia/cypress';
+import {faker} from '@faker-js/faker';
+
+/**
+ * The OAuth result page hands the authentication state back to the opener window
+ * through an inline script. That state is a boolean, and the view must always emit
+ * it as a well-formed boolean literal derived from the request — regardless of what
+ * the `isAuthenticate` query parameter actually contains. These tests pin that
+ * contract: the flag is rendered as `true`/`false` and an unexpected value is
+ * coerced, never echoed into the script verbatim.
+ */
+describe('OAuth result page — authentication-state flag rendering', () => {
+    let siteKey: string;
+
+    const renderUrl = (rawFlag: string): string =>
+        `/cms/render/live/en/sites/${siteKey}/oauth-result.html?isAuthenticate=${rawFlag}`;
+
+    beforeEach(() => {
+        siteKey = faker.lorem.slug();
+        createSite(siteKey, {
+            locale: 'en',
+            serverName: 'localhost',
+            templateSet: 'jahia-oauth-test-module'
+        });
+        publishAndWaitJobEnding(`/sites/${siteKey}`);
+        enableModule('jahia-oauth', siteKey);
+        publishAndWaitJobEnding(`/sites/${siteKey}`);
+        // The result page is public; exercise it as an anonymous visitor.
+        cy.logout();
+    });
+
+    afterEach(() => {
+        cy.logout();
+        deleteSite(siteKey);
+    });
+
+    it('emits a boolean literal for the authenticated flag', () => {
+        cy.request(renderUrl('true')).then(res => {
+            expect(res.status).to.eq(200);
+            expect(res.body).to.contain('isAuthenticate: true');
+        });
+    });
+
+    it('emits a boolean literal for the unauthenticated flag', () => {
+        cy.request(renderUrl('false')).then(res => {
+            expect(res.status).to.eq(200);
+            expect(res.body).to.contain('isAuthenticate: false');
+        });
+    });
+
+    it('coerces an unexpected flag value to a boolean literal instead of echoing it', () => {
+        const rawFlag = encodeURIComponent("</script><script>document.title='PROBE-HIT'</script><script>//");
+        cy.request(renderUrl(rawFlag)).then(res => {
+            expect(res.status).to.eq(200);
+            // The value is coerced to a well-formed boolean literal...
+            expect(res.body).to.contain('isAuthenticate: false');
+            // ...and never lands in the page as raw markup.
+            expect(res.body).not.to.contain('PROBE-HIT');
+        });
+    });
+});

--- a/tests/jahia-module/src/main/import/repository.xml
+++ b/tests/jahia-module/src/main/import/repository.xml
@@ -89,6 +89,9 @@
                                   jcr:mixinTypes="mix:title"
                                   jcr:primaryType="jnt:translation"
                                   jcr:title="Authentication Result"/>
+                <pagecontent jcr:primaryType="jnt:contentList">
+                    <oauth-result-view jcr:primaryType="joant:oauthResult"/>
+                </pagecontent>
             </oauth-result>
         </jahia-oauth-test-module>
     </modules>


### PR DESCRIPTION
## Summary

The OAuth result view (`joant:oauthResult`) reports the authentication outcome back to the
opener window through an inline script. It built that script by dropping the raw
`isAuthenticate` request parameter straight into a JavaScript object literal, and delivered the
message to a wildcard target (`'*'`). `isAuthenticate` is only ever a boolean, so when the
parameter held anything else the emitted script was not a well-formed literal, and the handshake
was posted to windows beyond the page's own origin.

## Change

- `oauthResult.jsp`: emit `isAuthenticate` as a boolean literal derived from the request
  (`${param.isAuthenticate eq 'true'}`), so the inline script always contains a valid
  `true`/`false` token regardless of the query value.
- Target the `postMessage` handshake at the page's own origin (`window.location.origin`) rather
  than `'*'`, so the authentication state is delivered only to the intended opener.
- Test module: add a `joant:oauthResult` component to the `oauth-result` page so the view can be
  exercised end to end.
- Add an e2e regression spec (`oauthResult.cy.ts`) asserting the flag renders as a boolean literal
  and that an unexpected `isAuthenticate` value is coerced rather than echoed into the page.

## Verification

- Built both bundles (JDK 11) and deployed to a local Jahia 8.2 (`8-SNAPSHOT`); both reach ACTIVE.
- The new Cypress spec passes on this change and fails on the prior behaviour: the boolean-literal
  contract holds, and an unexpected `isAuthenticate` value renders as `false` without appearing
  verbatim in the rendered page.
