### PR TITLE
fix: emit a well-formed boolean for the OAuth result outcome flag

### DIFF
--- a/.chachalog/UAuMP9ia.md
+++ b/.chachalog/UAuMP9ia.md
@@ -1,0 +1,5 @@
+---
+jahia-oauth: patch
+---
+
+Emit a well-formed boolean for the OAuth result outcome flag and scope the result message to the current origin

--- a/src/main/resources/joant_oauthResult/html/oauthResult.jsp
+++ b/src/main/resources/joant_oauthResult/html/oauthResult.jsp
@@ -26,7 +26,7 @@
         <template:addResources>
             <script>
                 (function() {
-                    window.opener.postMessage({authenticationIsDone: true, isAuthenticate: ${param.isAuthenticate}}, '*');
+                    window.opener.postMessage({authenticationIsDone: true, isAuthenticate: ${param.isAuthenticate eq 'true'}}, window.location.origin);
 
                     <c:if test="${param.isAuthenticate eq true}">
                         console.log('This window will be closed in 3 sec');

--- a/tests/cypress/e2e/oauthResultView.cy.ts
+++ b/tests/cypress/e2e/oauthResultView.cy.ts
@@ -1,0 +1,88 @@
+import {
+    createSite,
+    deleteSite,
+    enableModule,
+    publishAndWaitJobEnding
+} from '@jahia/cypress';
+import {faker} from '@faker-js/faker';
+
+/**
+ * Robustness tests for the OAuth result view (joant:oauthResult / oauthResult.jsp).
+ *
+ * The view emits an inline script that hands the authentication outcome back to the
+ * opener window via postMessage. The `isAuthenticate` value in that message is a
+ * boolean outcome flag, and the message target must be the current origin. These
+ * tests pin that contract: the emitted value is always a well-formed boolean literal
+ * derived from the request, never a verbatim echo of the raw request parameter, and
+ * the message is scoped to window.location.origin.
+ */
+describe('OAuth result view - request parameter handling', () => {
+    let siteKey: string;
+
+    const resultPath = () => `/sites/${siteKey}/oauth-result.html`;
+
+    // A parameter value that is not a well-formed boolean and contains script-context
+    // delimiters. A correct view coerces this to the boolean literal `false`; an
+    // unguarded view would splice it verbatim into the inline script.
+    const malformedFlag = "</script><script>document.title='PROBE-HIT'</script><script>//";
+
+    before(() => {
+        siteKey = faker.lorem.slug();
+        createSite(siteKey, {
+            locale: 'en',
+            serverName: 'localhost',
+            templateSet: 'jahia-oauth-test-module'
+        });
+        publishAndWaitJobEnding(`/sites/${siteKey}`);
+        enableModule('jahia-oauth', siteKey);
+        publishAndWaitJobEnding(`/sites/${siteKey}`);
+    });
+
+    after(() => {
+        deleteSite(siteKey);
+    });
+
+    beforeEach(() => {
+        // The result page is a public, unauthenticated view.
+        cy.logout();
+    });
+
+    it('emits a boolean literal (not the raw parameter) for a malformed isAuthenticate value', () => {
+        cy.request({
+            url: resultPath(),
+            qs: {isAuthenticate: malformedFlag},
+            failOnStatusCode: false
+        }).then(response => {
+            expect(response.status).to.eq(200);
+            // The outcome flag is coerced to a well-formed boolean literal...
+            expect(response.body).to.include('isAuthenticate: false');
+            // ...and the raw parameter text is never spliced back into the script.
+            expect(response.body).to.not.include("document.title='PROBE-HIT'");
+            expect(response.body).to.not.include('</script><script>');
+        });
+    });
+
+    it('preserves the true outcome on the normal (success) path', () => {
+        cy.request({
+            url: resultPath(),
+            qs: {isAuthenticate: 'true'},
+            failOnStatusCode: false
+        }).then(response => {
+            expect(response.status).to.eq(200);
+            expect(response.body).to.include('isAuthenticate: true');
+        });
+    });
+
+    it('scopes the postMessage to the current origin rather than a wildcard target', () => {
+        cy.request({
+            url: resultPath(),
+            qs: {isAuthenticate: 'true'},
+            failOnStatusCode: false
+        }).then(response => {
+            expect(response.status).to.eq(200);
+            expect(response.body).to.include('window.opener.postMessage');
+            expect(response.body).to.include('window.location.origin');
+            expect(response.body).to.not.include("}, '*')");
+        });
+    });
+});


### PR DESCRIPTION
## Summary

The OAuth result view (`joant:oauthResult`) emits an inline script that reports the
authentication outcome back to the opener window. The `isAuthenticate` outcome flag was
written into that script directly from the raw request parameter, so a non-boolean
request value produced malformed JavaScript, and the message was broadcast with a
wildcard (`'*'`) target.

## Change

- Emit `isAuthenticate` as a well-formed boolean literal derived from the request
  (`${param.isAuthenticate eq 'true'}`) instead of splicing the raw parameter into the
  script. The value the view already uses everywhere else is a boolean, so the output is
  now always `true`/`false`.
- Scope the `postMessage` target to `window.location.origin` rather than the `'*'`
  wildcard, so the outcome is delivered only to the current origin.

## Verification

- Added a self-contained regression spec (`tests/cypress/e2e/oauthResultView.cy.ts`)
  that renders the result page in live mode and asserts: a malformed `isAuthenticate`
  value is coerced to the boolean literal `false` and is not echoed verbatim into the
  script; the normal success path still emits `true`; and the message is scoped to the
  current origin. The spec is written to fail against the previous behaviour and pass
  with this change, and ships with the PR to run in CI.
- Reviewed the change against the view's existing uses of `isAuthenticate` (both are
  boolean tests), confirming the non-boolean output path is the only behaviour affected.
- Built the module locally to confirm it packages cleanly. The change is limited to a
  view template, so no bundle or API surface is affected.
