### PR TITLE
fix: render oauth-result authentication flag as a well-formed boolean literal

### DIFF
--- a/.chachalog/EyO4y.md
+++ b/.chachalog/EyO4y.md
@@ -1,0 +1,5 @@
+---
+jahia-oauth: patch
+---
+
+Render the oauth-result authentication flag as a well-formed boolean literal

--- a/src/main/resources/joant_oauthResult/html/oauthResult.jsp
+++ b/src/main/resources/joant_oauthResult/html/oauthResult.jsp
@@ -26,7 +26,7 @@
         <template:addResources>
             <script>
                 (function() {
-                    window.opener.postMessage({authenticationIsDone: true, isAuthenticate: ${param.isAuthenticate}}, '*');
+                    window.opener.postMessage({authenticationIsDone: true, isAuthenticate: ${param.isAuthenticate eq 'true'}}, window.location.origin);
 
                     <c:if test="${param.isAuthenticate eq true}">
                         console.log('This window will be closed in 3 sec');

--- a/tests/cypress/e2e/oauthResultFlag.cy.ts
+++ b/tests/cypress/e2e/oauthResultFlag.cy.ts
@@ -1,0 +1,84 @@
+import {
+    createSite,
+    deleteSite,
+    enableModule,
+    publishAndWaitJobEnding,
+    addNode
+} from '@jahia/cypress';
+import {faker} from '@faker-js/faker';
+
+/**
+ * Robustness checks for the oauth-result view.
+ *
+ * The view emits the authentication outcome as an inline JavaScript value:
+ *   window.opener.postMessage({authenticationIsDone: true, isAuthenticate: <flag>}, ...)
+ *
+ * `<flag>` is derived from the `isAuthenticate` request parameter. It must always render as a
+ * well-formed boolean literal (`true` / `false`) regardless of what the caller passes, so the
+ * emitted script is always syntactically valid and never carries arbitrary request text into the
+ * page. These tests place the oauth-result component on a published page and render it in live
+ * mode as a guest, exercising both a normal value and a hostile one.
+ */
+describe('oauth-result authentication flag', () => {
+    let siteKey: string;
+    let pagePath: string;
+
+    // A value that, if reflected verbatim, would break out of the inline <script> block and
+    // introduce a foreign statement. A well-formed boolean literal never contains this marker.
+    const MARKER = 'oauthFlagProbe12345';
+    const HOSTILE = `</script><script>window.${MARKER}=1</script><script>//`;
+
+    beforeEach(() => {
+        siteKey = faker.lorem.slug();
+        // The home page of this template set does not render (empty 200); the connector
+        // pages (e.g. google) do. Place the component on a rendering page.
+        pagePath = `/sites/${siteKey}/google`;
+
+        createSite(siteKey, {
+            locale: 'en',
+            serverName: 'localhost',
+            templateSet: 'jahia-oauth-test-module'
+        });
+        enableModule('jahia-oauth', siteKey);
+
+        // The page template renders a `pagecontent` area; place the component there.
+        addNode({
+            parentPathOrId: pagePath,
+            primaryNodeType: 'jnt:contentList',
+            name: 'pagecontent'
+        });
+        addNode({
+            parentPathOrId: `${pagePath}/pagecontent`,
+            primaryNodeType: 'joant:oauthResult',
+            name: 'authentication-result'
+        });
+        publishAndWaitJobEnding(`/sites/${siteKey}`);
+    });
+
+    afterEach(() => {
+        deleteSite(siteKey);
+    });
+
+    const renderLive = (isAuthenticate: string) =>
+        cy.request({
+            url: `${Cypress.config().baseUrl}/cms/render/live/en${pagePath}.html`,
+            qs: {isAuthenticate},
+            failOnStatusCode: false
+        });
+
+    it('emits a boolean literal for a normal affirmative value', () => {
+        renderLive('true').then(response => {
+            expect(response.status).to.eq(200);
+            expect(response.body).to.contain('isAuthenticate: true');
+        });
+    });
+
+    it('coerces an unexpected value to a boolean literal rather than reflecting it', () => {
+        renderLive(HOSTILE).then(response => {
+            expect(response.status).to.eq(200);
+            // The flag must degrade to a well-formed boolean, not carry the raw value through.
+            expect(response.body).to.contain('isAuthenticate: false');
+            expect(response.body).not.to.contain(MARKER);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

The `joant:oauthResult` view emits its authentication outcome from an inline `postMessage` script:

```js
window.opener.postMessage({authenticationIsDone: true, isAuthenticate: <flag>}, <target>);
```

Two robustness issues on this line:

1. `<flag>` was dropped straight into the script as a bare, unquoted token
   (`${param.isAuthenticate}`). Because the value is written verbatim, anything other than a clean
   `true`/`false` produces a malformed script fragment rather than the boolean the rest of the view
   expects.
2. `<target>` was the wildcard `'*'`, so the outcome message was posted to any window rather than
   the page's own origin.

## Change

`joant_oauthResult/html/oauthResult.jsp`:

- Emit the flag as a boolean expression `${param.isAuthenticate eq 'true'}`, so the token written
  into the inline `postMessage` object is always a valid `true` or `false` literal. This mirrors
  the boolean tests the same view already uses for `isAuthenticate` (the
  `${param.isAuthenticate eq true}` guard and the `${param.isAuthenticate}` branch condition),
  keeping the three uses of the flag consistent.
- Scope the `postMessage` target to `window.location.origin` instead of `'*'`, so the message
  reaches the page's own origin.

No behavior change on the normal success/error result flows: a request carrying
`isAuthenticate=true` still emits `true` and the same-origin opener still receives the message; the
error/absent case still emits `false`.

## Verification

- Built the module and deployed it to a local Jahia; the `joant:oauthResult` bundle reaches
  **ACTIVE**.
- Rendered the `joant:oauthResult` component on a published page in live mode with a range of
  `isAuthenticate` values. The inline script now always emits `isAuthenticate: true` or
  `isAuthenticate: false` — never the raw request value — so the object passed to `postMessage` is
  always well-formed.
- Legitimate success (`isAuthenticate=true`) and error (`isAuthenticate=false` / absent) results
  render and behave exactly as before.
- Ships a regression spec (`tests/cypress/e2e/oauthResultFlag.cy.ts`) that renders the view with an
  unexpected flag value and asserts the emitted line is a boolean literal (fails on the previous
  behavior, passes with this change).
