### PR TITLE
fix: emit a boolean literal for the isAuthenticate parameter in the oauth result view

### DIFF
--- a/.chachalog/LXTu9.md
+++ b/.chachalog/LXTu9.md
@@ -1,0 +1,5 @@
+---
+jahia-oauth: patch
+---
+
+Emit a boolean literal for the isAuthenticate parameter in the oauth result view

--- a/src/main/resources/joant_oauthResult/html/oauthResult.jsp
+++ b/src/main/resources/joant_oauthResult/html/oauthResult.jsp
@@ -26,7 +26,7 @@
         <template:addResources>
             <script>
                 (function() {
-                    window.opener.postMessage({authenticationIsDone: true, isAuthenticate: ${param.isAuthenticate}}, '*');
+                    window.opener.postMessage({authenticationIsDone: true, isAuthenticate: ${param.isAuthenticate eq 'true'}}, '*');
 
                     <c:if test="${param.isAuthenticate eq true}">
                         console.log('This window will be closed in 3 sec');

--- a/tests/cypress/e2e/oauthResultParameter.cy.ts
+++ b/tests/cypress/e2e/oauthResultParameter.cy.ts
@@ -1,0 +1,67 @@
+import {
+    addNode,
+    createSite,
+    deleteSite,
+    enableModule,
+    publishAndWaitJobEnding
+} from '@jahia/cypress';
+import {faker} from '@faker-js/faker';
+
+/**
+ * The oauthResult view echoes the `isAuthenticate` request parameter into an inline
+ * script as the value of an object property. That position expects a boolean literal,
+ * so the view must always emit a well-formed `true` / `false` token derived from the
+ * parameter — never the raw parameter text. This suite renders the component in live
+ * mode and asserts the emitted script stays well-formed whatever the parameter holds.
+ */
+describe('oauthResult view - isAuthenticate parameter rendering', () => {
+    let siteKey: string;
+
+    // The test template set ships page templates for the connector pages (facebook, google,
+    // linkedin, github) but not for `home`, so `home.html` renders empty. Render on `facebook`,
+    // which has a working template and a `pagecontent` area, in live mode.
+    const renderUrl = (value: string) =>
+        `/cms/render/live/en/sites/${siteKey}/facebook.html?isAuthenticate=${value}`;
+
+    beforeEach(() => {
+        siteKey = faker.lorem.slug();
+        createSite(siteKey, {
+            locale: 'en',
+            serverName: 'localhost',
+            templateSet: 'jahia-oauth-test-module'
+        });
+        enableModule('jahia-oauth', siteKey);
+
+        // Render the oauthResult component from the facebook page content area (live mode).
+        addNode({
+            parentPathOrId: `/sites/${siteKey}/facebook/pagecontent`,
+            name: 'authentication-result',
+            primaryNodeType: 'joant:oauthResult'
+        });
+        publishAndWaitJobEnding(`/sites/${siteKey}`);
+        cy.logout();
+    });
+
+    afterEach(() => {
+        deleteSite(siteKey);
+    });
+
+    it('emits a false boolean literal when the parameter is not the string true', () => {
+        const raw = encodeURIComponent("</script><script>document.title='probe'</script><script>//");
+        cy.request(renderUrl(raw)).then(response => {
+            expect(response.status).to.eq(200);
+            // The property value is a boolean literal derived from the parameter...
+            expect(response.body).to.contain('isAuthenticate: false');
+            // ...and the raw parameter text never reaches the script structure.
+            expect(response.body).to.not.contain("document.title='probe'");
+            expect(response.body).to.not.contain('</script><script>');
+        });
+    });
+
+    it('emits a true boolean literal for the authenticated flow', () => {
+        cy.request(renderUrl('true')).then(response => {
+            expect(response.status).to.eq(200);
+            expect(response.body).to.contain('isAuthenticate: true');
+        });
+    });
+});


### PR DESCRIPTION
## Summary

The `oauthResult` view echoes the `isAuthenticate` request parameter into an inline
`postMessage` call as the value of an object property — a position that expects a boolean
literal. It previously emitted the parameter's raw text, so a non-boolean parameter value
produced a malformed inline script instead of a well-formed `true` / `false`.

## Change

Coerce the parameter to a boolean literal at the sink:

```jsp
isAuthenticate: ${param.isAuthenticate eq 'true'}
```

The emitted value is now always `true` or `false`, regardless of the parameter's raw content.
Behaviour on the normal flow is unchanged — the view already treats `isAuthenticate` as a
boolean everywhere else (the success/error message branch and the auto-close countdown), so a
request with `isAuthenticate=true` still emits `true` exactly as before.

## Verification

Added a self-contained Cypress spec (`tests/cypress/e2e/oauthResultParameter.cy.ts`) that
enables the module on a fresh site, renders the `oauthResult` component in live mode, and
asserts the emitted inline script:

- contains `isAuthenticate: false` when the parameter is a non-boolean value (and the raw
  parameter text never reaches the script structure), and
- contains `isAuthenticate: true` for the authenticated flow (`isAuthenticate=true`).

The spec fails against the previous behaviour (which reflected the raw parameter text) and
passes with this change.
