### PR TITLE
fix: emit a well-formed boolean for the OAuth result authentication flag

### DIFF
--- a/.chachalog/i7nli7Pz.md
+++ b/.chachalog/i7nli7Pz.md
@@ -1,0 +1,5 @@
+---
+jahia-oauth: patch
+---
+
+Render the OAuth result authentication flag as a well-formed boolean and target the result message at the page origin

--- a/src/main/resources/joant_oauthResult/html/oauthResult.jsp
+++ b/src/main/resources/joant_oauthResult/html/oauthResult.jsp
@@ -26,7 +26,7 @@
         <template:addResources>
             <script>
                 (function() {
-                    window.opener.postMessage({authenticationIsDone: true, isAuthenticate: ${param.isAuthenticate}}, '*');
+                    window.opener.postMessage({authenticationIsDone: true, isAuthenticate: ${param.isAuthenticate eq 'true'}}, window.location.origin);
 
                     <c:if test="${param.isAuthenticate eq true}">
                         console.log('This window will be closed in 3 sec');

--- a/tests/cypress/e2e/oauthResult.cy.ts
+++ b/tests/cypress/e2e/oauthResult.cy.ts
@@ -1,0 +1,74 @@
+import {
+    createSite,
+    deleteSite,
+    enableModule,
+    publishAndWaitJobEnding
+} from '@jahia/cypress';
+import {faker} from '@faker-js/faker';
+
+/**
+ * The OAuth result view renders an inline script that hands the authentication
+ * outcome to the opener window via postMessage. Two correctness properties must
+ * hold regardless of the value supplied on the request URL:
+ *
+ *   1. The `isAuthenticate` request parameter is rendered as a well-formed
+ *      JavaScript boolean literal (`true` / `false`) — it is a boolean flag, so
+ *      an arbitrary request-parameter value must never reach the inline script
+ *      verbatim (which would emit malformed / arbitrary JavaScript).
+ *   2. The message targets the page's own origin, not the `'*'` wildcard.
+ *
+ * The view is rendered live and is reachable by an unauthenticated visitor, so
+ * the assertions run as a guest request against the rendered HTML.
+ */
+describe('OAuth result view — authentication flag rendering', () => {
+    let siteKey: string;
+
+    before(() => {
+        siteKey = faker.lorem.slug();
+        createSite(siteKey, {
+            locale: 'en',
+            serverName: 'localhost',
+            templateSet: 'jahia-oauth-test-module'
+        });
+        publishAndWaitJobEnding(`/sites/${siteKey}`);
+        enableModule('jahia-oauth', siteKey);
+        cy.logout();
+    });
+
+    after(() => {
+        deleteSite(siteKey);
+    });
+
+    const renderResultPage = (isAuthenticate: string) =>
+        cy.request({
+            url: `/sites/${siteKey}/oauth-result.html`,
+            qs: {isAuthenticate},
+            failOnStatusCode: false
+        });
+
+    it('renders the flag as a boolean literal for a well-formed value', () => {
+        renderResultPage('true').then(res => {
+            expect(res.status).to.eq(200);
+            expect(res.body).to.contain('isAuthenticate: true');
+        });
+    });
+
+    it('coerces an arbitrary parameter value to a boolean and never reflects it into the inline script', () => {
+        const marker = `zzflag${faker.string.alphanumeric(8)}`;
+        const raw = `</script><script>document.title='${marker}'</script><script>//`;
+        renderResultPage(raw).then(res => {
+            expect(res.status).to.eq(200);
+            // The non-"true" value is coerced to the boolean literal false ...
+            expect(res.body).to.contain('isAuthenticate: false');
+            // ... and the raw request value never appears in the rendered response.
+            expect(res.body).not.to.contain(marker);
+        });
+    });
+
+    it('targets the message at the page origin rather than the wildcard', () => {
+        renderResultPage('true').then(res => {
+            expect(res.body).to.contain('window.location.origin');
+            expect(res.body).not.to.contain(", '*')");
+        });
+    });
+});


### PR DESCRIPTION
## Summary

The OAuth result view (`joant:oauthResult`) renders an inline script that relays the
authentication outcome to the window that opened it, via `postMessage`. The `isAuthenticate`
request parameter was written into that script verbatim, so any non-boolean value produced
malformed JavaScript, and the message was broadcast to a `'*'` target instead of the page's own
window.

## Change

- Render `isAuthenticate` as a boolean literal (`${param.isAuthenticate eq 'true'}`) so the emitted
  script is always well-formed regardless of the request value. The flag is a boolean — the button
  views that receive the message (`if (event.data.isAuthenticate)`) already treat it as one — so this
  is behavior-preserving on the normal path.
- Target the `postMessage` at the page's own origin (`window.location.origin`) rather than the `'*'`
  wildcard, so the message is delivered only to the expected window.

## Verification

- Added a Cypress regression spec (`tests/cypress/e2e/oauthResult.cy.ts`) that renders the result
  page as a guest and asserts: the emitted flag is a boolean literal for a well-formed value; an
  arbitrary request value is coerced to `false` and never copied verbatim into the inline script; and
  the message targets the page origin rather than the wildcard.
- Built the module (JDK 11) and ran the spec against a live instance — green on this change, red
  before it.
