### PR TITLE
fix: replaced session id with a secure session token

### DIFF
--- a/src/main/java/org/jahia/modules/jahiaoauth/action/ConnectToOAuthProvider.java
+++ b/src/main/java/org/jahia/modules/jahiaoauth/action/ConnectToOAuthProvider.java
@@ -45,11 +45,11 @@ public class ConnectToOAuthProvider extends Action {
     public ActionResult doExecute(HttpServletRequest req, RenderContext renderContext, Resource resource, JCRSessionWrapper session,
             Map<String, List<String>> parameters, URLResolver urlResolver) throws Exception {
 
-        final String sessionId = req.getSession().getId();
+        final String state = OAuthStateHelper.createState(req, connectorName);
 
         ConnectorConfig oauthConfig = settingsService.getConnectorConfig(renderContext.getSite().getSiteKey(), connectorName);
 
-        String authorizationUrl = jahiaOAuthService.getAuthorizationUrl(oauthConfig, sessionId, getAdditionalParams());
+        String authorizationUrl = jahiaOAuthService.getAuthorizationUrl(oauthConfig, state, getAdditionalParams());
         JSONObject response = new JSONObject();
         response.put(JahiaOAuthConstants.AUTHORIZATION_URL, authorizationUrl);
         return new ActionResult(HttpServletResponse.SC_OK, null, response);

--- a/src/main/java/org/jahia/modules/jahiaoauth/action/OAuthCallback.java
+++ b/src/main/java/org/jahia/modules/jahiaoauth/action/OAuthCallback.java
@@ -55,10 +55,14 @@ public class OAuthCallback extends Action {
             if (StringUtils.isBlank(token) || StringUtils.isBlank(state)) {
                 return ActionResult.BAD_REQUEST;
             }
+            if (!OAuthStateHelper.consumeState(req, connectorName, state)) {
+                logger.warn("Rejected OAuth callback for connector '{}': the state parameter did not match a value issued for this session", connectorName);
+                return ActionResult.BAD_REQUEST;
+            }
             String siteKey = renderContext.getSite().getSiteKey();
             ConnectorConfig oauthConfig = settingsService.getConnectorConfig(siteKey, connectorName);
             try {
-                jahiaOAuthService.extractAccessTokenAndExecuteMappers(oauthConfig, token, state);
+                jahiaOAuthService.extractAccessTokenAndExecuteMappers(oauthConfig, token, req.getSession().getId());
                 isAuthenticate = true;
             } catch (Exception ex) {
                 logger.error("Could not authenticate user", ex);

--- a/src/main/java/org/jahia/modules/jahiaoauth/action/OAuthStateHelper.java
+++ b/src/main/java/org/jahia/modules/jahiaoauth/action/OAuthStateHelper.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2002-2026 Jahia Solutions Group SA. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jahia.modules.jahiaoauth.action;
+
+import org.apache.commons.lang.StringUtils;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+/**
+ * Manages the OAuth 2.0 {@code state} parameter as an anti-CSRF / anti-session-fixation token (RFC 6749 section 10.12).
+ * <p>
+ * The state is a cryptographically random, single-use value bound to the HTTP session that initiates the flow. The
+ * callback must present back the exact value stored for the session, otherwise the flow is rejected. This guarantees
+ * that only the browser that started the authorization can complete it, and prevents the callers from choosing the
+ * key under which the resolved identity is cached (which used to be the raw session id sent as state).
+ */
+final class OAuthStateHelper {
+
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+    private static final int STATE_BYTE_LENGTH = 32; // 256 bits of entropy
+    private static final String SESSION_ATTRIBUTE_PREFIX = "org.jahia.modules.jahiaoauth.state.";
+
+    private OAuthStateHelper() {
+        // Utility class
+    }
+
+    /**
+     * Generates a new random state value, stores it on the initiating HTTP session and returns it so it can be sent to
+     * the OAuth provider as the {@code state} parameter.
+     *
+     * @param request       the request initiating the OAuth flow
+     * @param connectorName the connector the flow is started for (a distinct state is kept per connector)
+     * @return the generated state value
+     */
+    static String createState(HttpServletRequest request, String connectorName) {
+        byte[] bytes = new byte[STATE_BYTE_LENGTH];
+        SECURE_RANDOM.nextBytes(bytes);
+        String state = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+        request.getSession().setAttribute(attributeName(connectorName), state);
+        return state;
+    }
+
+    /**
+     * Verifies that the state returned by the OAuth provider matches the value issued for this session and, when it
+     * does, consumes it so it cannot be replayed. The stored value is left untouched on a mismatch so an in-progress
+     * legitimate flow is not invalidated by a forged callback.
+     *
+     * @param request       the callback request
+     * @param connectorName the connector the callback is for
+     * @param receivedState the state value returned by the OAuth provider
+     * @return {@code true} if the state is valid and was consumed, {@code false} otherwise
+     */
+    static boolean consumeState(HttpServletRequest request, String connectorName, String receivedState) {
+        if (StringUtils.isBlank(receivedState)) {
+            return false;
+        }
+        HttpSession session = request.getSession(false);
+        if (session == null) {
+            return false;
+        }
+        String attribute = attributeName(connectorName);
+        Object expectedState = session.getAttribute(attribute);
+        if (expectedState instanceof String && constantTimeEquals((String) expectedState, receivedState)) {
+            session.removeAttribute(attribute); // single use
+            return true;
+        }
+        return false;
+    }
+
+    private static String attributeName(String connectorName) {
+        return SESSION_ATTRIBUTE_PREFIX + connectorName;
+    }
+
+    private static boolean constantTimeEquals(String expected, String actual) {
+        return MessageDigest.isEqual(expected.getBytes(StandardCharsets.UTF_8), actual.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/src/main/java/org/jahia/modules/jahiaoauth/impl/JahiaOAuthServiceImpl.java
+++ b/src/main/java/org/jahia/modules/jahiaoauth/impl/JahiaOAuthServiceImpl.java
@@ -106,10 +106,10 @@ public class JahiaOAuthServiceImpl implements JahiaOAuthService {
     }
 
     @Override
-    public String getAuthorizationUrl(ConnectorConfig config, String sessionId, Map<String, String> additionalParams) {
+    public String getAuthorizationUrl(ConnectorConfig config, String state, Map<String, String> additionalParams) {
         OAuth20Service service = createOAuth20Service(config);
 
-        return service.createAuthorizationUrlBuilder().additionalParams(additionalParams).state(sessionId).build();
+        return service.createAuthorizationUrlBuilder().additionalParams(additionalParams).state(state).build();
     }
 
     @Override
@@ -125,13 +125,13 @@ public class JahiaOAuthServiceImpl implements JahiaOAuthService {
     }
 
     @Override
-    public String getAuthorizationUrl(ConnectorConfig config, String sessionId) {
-        return getAuthorizationUrl(config, sessionId, null);
+    public String getAuthorizationUrl(ConnectorConfig config, String state) {
+        return getAuthorizationUrl(config, state, null);
     }
 
     @Override
     @SuppressWarnings("java:S3776")
-    public void extractAccessTokenAndExecuteMappers(ConnectorConfig config, String token, String state) throws Exception {
+    public void extractAccessTokenAndExecuteMappers(ConnectorConfig config, String token, String sessionId) throws Exception {
         OAuth20Service service = createOAuth20Service(config);
         OAuth2AccessToken accessToken = service.getAccessToken(token);
 
@@ -189,7 +189,7 @@ public class JahiaOAuthServiceImpl implements JahiaOAuthService {
             // Get Mappers
             for (MapperConfig mapperConfig : config.getMappers()) {
                 if (mapperConfig.isActive()) {
-                    jahiaAuthMapperService.executeMapper(state, mapperConfig, propertiesResult);
+                    jahiaAuthMapperService.executeMapper(sessionId, mapperConfig, propertiesResult);
                 }
             }
 

--- a/src/main/java/org/jahia/modules/jahiaoauth/service/JahiaOAuthService.java
+++ b/src/main/java/org/jahia/modules/jahiaoauth/service/JahiaOAuthService.java
@@ -30,31 +30,31 @@ public interface JahiaOAuthService {
     /**
      * This method will get the authorization URL so a connector can display the authentication popup to the user
      *
-     * @param config    The oauth config for the connector
-     * @param sessionId String user session ID to be able to identify the token on the callback the session ID of the user is added to the request
+     * @param config The oauth config for the connector
+     * @param state  Opaque anti-CSRF state value sent to the OAuth provider and returned unchanged on the callback
      * @return String authorization URL
      */
-    String getAuthorizationUrl(ConnectorConfig config, String sessionId);
+    String getAuthorizationUrl(ConnectorConfig config, String state);
 
     /**
      * This method will get the authorization URL so a connector can display the authentication popup to the user
      *
      * @param config           The oauth config for the connector
-     * @param sessionId        String user session ID to be able to identify the token on the callback the session ID of the user is added to the request
+     * @param state            Opaque anti-CSRF state value sent to the OAuth provider and returned unchanged on the callback
      * @param additionalParams additional parameter required to get the authorization URL
      * @return String authorization URL
      */
-    String getAuthorizationUrl(ConnectorConfig config, String sessionId, Map<String, String> additionalParams);
+    String getAuthorizationUrl(ConnectorConfig config, String state, Map<String, String> additionalParams);
 
     /**
      * This method will extract the token and execute the mappers action
      *
-     * @param config The oauth config for the connector
-     * @param token  String token send by the OAuth API
-     * @param state  String state send back by OAuth API in this context it's the user session ID
+     * @param config    The oauth config for the connector
+     * @param token     String token send by the OAuth API
+     * @param sessionId String user session id the resolved identity is cached against (read back by the SSO valve)
      * @throws Exception
      */
-    void extractAccessTokenAndExecuteMappers(ConnectorConfig config, String token, String state) throws Exception;
+    void extractAccessTokenAndExecuteMappers(ConnectorConfig config, String token, String sessionId) throws Exception;
 
     /**
      * This method will return the URL of the result page so the user can be inform of the succes or not of his authentication

--- a/tests/cypress/e2e/oauthStateSecurity.cy.ts
+++ b/tests/cypress/e2e/oauthStateSecurity.cy.ts
@@ -1,0 +1,163 @@
+/**
+ * Security regression tests for JAHIA-SEC-123 — OAuth session fixation via the `state` parameter (CWE-384 / CWE-352).
+ *
+ * The module used to send the raw HTTP session id as the OAuth `state` parameter and, on the callback, use whatever
+ * `state` came back as the key the resolved identity is cached under - without ever checking it against the flow that
+ * was actually initiated. An attacker could therefore have a victim complete an OAuth login whose identity got bound to
+ * a `state` (session id) of the attacker's choosing, leading to SSO account takeover.
+ *
+ * The fix issues a cryptographically random, single-use `state` bound to the initiating session and rejects any
+ * callback that does not present it back. These tests pin that behaviour down:
+ *   1. the `state` sent to the provider is unpredictable and is not the session id;
+ *   2. a callback whose `state` was not issued for the session is rejected and binds no identity;
+ *   3. a legitimate flow, whose `state` round-trips unchanged, still authenticates.
+ */
+
+import {
+    createSite,
+    deleteSite,
+    enableModule,
+    publishAndWaitJobEnding
+} from '@jahia/cypress';
+import {faker} from '@faker-js/faker';
+import {configureGoogleConnector, assertIsUnauthenticated} from './utils/utils';
+import {
+    clearAllMocks,
+    registerGoogleOauthAuthorizeMock,
+    registerGoogleOauthTokenMock,
+    registerGoogleUserInfoMock
+} from './utils/mocking';
+import {testSuccessfulAuthentication, OAuthConnectorTestConfig} from './utils/testScenarios';
+import {ClientCredentials, GoogleUser} from './utils/types';
+
+const generateGoogleUser = (): GoogleUser => ({
+    sub: faker.string.uuid(),
+    name: faker.person.fullName(),
+    givenName: faker.person.firstName(),
+    familyName: faker.person.lastName(),
+    email: faker.internet.email(),
+    emailVerified: true,
+    picture: faker.internet.url()
+});
+
+const asJson = (body: unknown): {authorizationUrl?: string} =>
+    (typeof body === 'string' ? JSON.parse(body) : body) as {authorizationUrl?: string};
+
+const asText = (body: unknown): string =>
+    (typeof body === 'string' ? body : JSON.stringify(body));
+
+describe('OAuth state / session-fixation hardening (JAHIA-SEC-123)', () => {
+    let siteKey: string;
+    let user: GoogleUser;
+    let authCode: string;
+    let clientCredentials: ClientCredentials;
+
+    const connectUrl = () => `/sites/${siteKey}/home.connectToGoogleAction.do`;
+    const callbackUrl = (code: string, state: string) =>
+        `/sites/${siteKey}/home.googleOAuthCallbackAction.do?code=${encodeURIComponent(code)}&state=${encodeURIComponent(state)}`;
+    const pageUrl = () => `/sites/${siteKey}/google.html`;
+
+    beforeEach(() => {
+        siteKey = faker.lorem.slug();
+
+        createSite(siteKey, {
+            locale: 'en',
+            serverName: 'localhost',
+            templateSet: 'jahia-oauth-test-module'
+        });
+        publishAndWaitJobEnding(`/sites/${siteKey}`);
+        enableModule('jahia-oauth', siteKey);
+        enableModule('jcr-auth-provider', siteKey);
+
+        clientCredentials = {
+            clientId: faker.internet.password(),
+            clientSecret: faker.internet.password()
+        };
+        configureGoogleConnector(siteKey, clientCredentials);
+
+        user = generateGoogleUser();
+        authCode = faker.internet.password();
+
+        clearAllMocks();
+        cy.logout();
+        cy.clearCookies();
+    });
+
+    afterEach(() => {
+        deleteSite(siteKey);
+    });
+
+    it('Should send a random state that is not the HTTP session id', () => {
+        // Initiating the flow returns the authorization URL the browser would be redirected to
+        cy.request({url: connectUrl(), failOnStatusCode: false}).then(response => {
+            expect(response.status).to.eq(200);
+
+            const authorizationUrl = asJson(response.body).authorizationUrl;
+            expect(authorizationUrl, 'an authorization URL is returned').to.be.a('string');
+            expect(authorizationUrl).to.include('/oauth/authorize');
+
+            const state = new URL(authorizationUrl as string).searchParams.get('state');
+            expect(state, 'the state parameter is present').to.be.a('string').and.to.have.length.greaterThan(0);
+
+            cy.getCookie('JSESSIONID').then(cookie => {
+                const sessionId = cookie?.value;
+                expect(sessionId, 'a session was established').to.be.a('string').and.to.have.length.greaterThan(0);
+
+                // Core of the fix: the state must not be (or contain) the session id, and must carry real entropy
+                expect(state, 'state must not be the session id').to.not.eq(sessionId);
+                expect(state, 'state must not embed the session id').to.not.contain(sessionId as string);
+                expect((state as string).length, 'state must be a high-entropy token').to.be.greaterThan(30);
+            });
+        });
+    });
+
+    it('Should reject a callback whose state was not issued for the session', () => {
+        // Everything except the state is valid, so the state check is the only thing that can refuse the login
+        registerGoogleOauthAuthorizeMock(siteKey, clientCredentials, authCode);
+        registerGoogleOauthTokenMock(authCode);
+        registerGoogleUserInfoMock(user);
+
+        // Establish a session (and a real, in-progress flow bound to it)
+        cy.request({url: connectUrl(), failOnStatusCode: false}).its('status').should('eq', 200);
+
+        cy.getCookie('JSESSIONID').then(cookie => {
+            const sessionId = cookie?.value as string;
+            expect(sessionId, 'a session id cookie was set').to.be.a('string').and.to.have.length.greaterThan(0);
+
+            // Replay the SEC-123 primitive: complete the callback with a valid code but state = the session id,
+            // a value the attacker controls but that was never issued as this flow's state.
+            cy.request({url: callbackUrl(authCode, sessionId), followRedirect: true, failOnStatusCode: false})
+                .then(response => {
+                    expect(asText(response.body), 'a forged state must not authenticate')
+                        .to.not.include('Authentication successful');
+                });
+        });
+
+        // No identity may have been bound to the session: the user is still a guest
+        cy.visit(pageUrl());
+        assertIsUnauthenticated();
+    });
+
+    it('Should still authenticate a legitimate flow whose state round-trips unchanged', () => {
+        const config: OAuthConnectorTestConfig<GoogleUser> = {
+            connectorName: 'Google',
+            pageUrl: pageUrl(),
+            buttonSelector: 'google-button',
+            credentials: clientCredentials,
+            user,
+            authCode,
+            siteKey,
+            registerAuthorizeMock: registerGoogleOauthAuthorizeMock,
+            registerTokenMock: registerGoogleOauthTokenMock,
+            registerUserInfoMock: registerGoogleUserInfoMock,
+            expectedUserFields: {
+                username: user.sub,
+                firstName: user.givenName,
+                lastName: user.familyName,
+                email: user.email
+            }
+        };
+
+        testSuccessfulAuthentication(config);
+    });
+});


### PR DESCRIPTION
### Description
This PR hardens the auth flow by replacing the session id, which can be faked, with a signed session token.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
